### PR TITLE
Add setup script with 10 second wait

### DIFF
--- a/.spawn-agent/setup.sh
+++ b/.spawn-agent/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+REPO_ROOT=$1
+WORKTREE_PATH=$2
+
+echo "⏳ Waiting 10 seconds..."
+sleep 10
+echo "✅ Done waiting"


### PR DESCRIPTION
## Summary
- Adds a `.spawn-agent/setup.sh` script that pauses for 10 seconds during worktree setup

## Test plan
- [ ] Run `spawn-agent <branch>` and verify the 10 second wait appears after worktree creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)