### PR TITLE
Address code review findings for plugin

### DIFF
--- a/plugin/src/ui.rs
+++ b/plugin/src/ui.rs
@@ -24,7 +24,7 @@ pub fn render_worktree_list(worktrees: &[Worktree], selected: usize, rows: usize
         return;
     }
 
-    let max_visible = rows.saturating_sub(5); // header + footer + margins
+    let max_visible = rows.saturating_sub(5).max(1); // header + footer + margins
     let start = if selected >= max_visible {
         selected - max_visible + 1
     } else {
@@ -51,7 +51,7 @@ pub fn render_branch_list(branches: &[String], selected: usize, rows: usize) {
     println!("{title}");
     println!();
 
-    let max_visible = rows.saturating_sub(7);
+    let max_visible = rows.saturating_sub(7).max(1);
     let start = if selected >= max_visible {
         selected - max_visible + 1
     } else {


### PR DESCRIPTION
## Summary

Addresses findings from the spawn-agent plugin code review (stacked on #6):

- **Error handling for `handle_list_worktrees` and `handle_git_branches`** — Failed git commands now surface errors via `status_message` instead of silently producing empty results. Existing data is preserved on failure.
- **Extract `wrap_navigate` helper** — DRYs up the duplicated j/k wrapping navigation logic across `handle_key_browse` and `handle_key_select_branch`.
- **Clear `input_buffer` on Esc** — Prevents stale text if new entry points to `InputBranch` are added.
- **Min 1 visible item in scroll calculations** — `max_visible.max(1)` ensures at least one item renders with very small terminal heights.
- **8 new tests** covering error paths, data preservation, buffer clearing, and `wrap_navigate`.

## Test plan

- [x] All 48 tests pass (`cargo test --target aarch64-apple-darwin`)
- [x] WASM build compiles (`cargo build --release`)
- [x] Plugin installed to `~/.config/zellij/plugins/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)