### PR TITLE
Show config file path in doctor output

### DIFF
--- a/zelligent.sh
+++ b/zelligent.sh
@@ -76,7 +76,7 @@ if [ "$1" = "doctor" ]; then
   touch "$CONFIG"
 
   if grep -qF 'zelligent-plugin.wasm' "$CONFIG"; then
-    echo "  keybinding: ok"
+    echo "  keybinding: ok ($CONFIG)"
   else
     cat >> "$CONFIG" <<KDL
 


### PR DESCRIPTION
## Summary
- Print the Zellij config file path alongside the keybinding status in `zelligent doctor`

## Test plan
- [ ] Run `zelligent doctor` and verify the config path is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)