### PR TITLE
Add CI workflow for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up remote HEAD
+        run: git remote set-head origin --auto
 
       - name: Run shell tests
         run: bash test.sh


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow that runs on every pull request
- **test-shell**: runs `bash test.sh` (shell unit/integration tests)
- **test-plugin**: runs `cargo test` and builds the WASM plugin

## Test plan
- [ ] Verify both jobs pass on this PR
- [ ] Enable branch protection on `main` requiring `test-shell` and `test-plugin` to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)