### PR TITLE
Rewrite README around quick start flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Zelligent runs AI coding agents in isolated git worktrees, each in its own [Zell
 
 You give it a branch name and an agent command. It creates a worktree, opens a new tab with the agent on the left and [lazygit](https://github.com/jesseduffield/lazygit) on the right. When you're done, it cleans up the worktree.
 
+Use the CLI to spawn worktrees, or press **`Ctrl-y`** inside Zellij to manage them from an interactive plugin UI.
+
 ## Quick start
 
 Install with Homebrew (pulls in Zellij and lazygit automatically):


### PR DESCRIPTION
## Summary

- Restructures the README to lead with the install → doctor → launch user flow
- Adds a "How it works" section explaining the CLI + WASM plugin architecture
- Removes redundant content and tightens language throughout
- Reviewed by a no-slop subagent for AI-isms and marketing fluff (one cliche removed)

## Test plan

- [ ] Read through the README and verify accuracy against actual CLI behavior
- [ ] Confirm all code examples are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)