### PR TITLE
Fix permissions.kdl missing file: prefix

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -281,6 +281,17 @@ CONFIG_CONTENT=$(cat "$MOCK_DR_HOME/.config/zellij/config.kdl")
 contains "doctor adds keybinding" "zelligent-plugin.wasm" "$CONFIG_CONTENT"
 contains "doctor adds Ctrl y" "Ctrl y" "$CONFIG_CONTENT"
 
+# doctor writes permissions with file: prefix matching the config keybinding
+if [ "$(uname)" = "Darwin" ]; then
+  PERM_FILE="$MOCK_DR_HOME/Library/Caches/org.Zellij-Contributors.Zellij/permissions.kdl"
+else
+  PERM_FILE="$MOCK_DR_HOME/.cache/zellij/permissions.kdl"
+fi
+check "doctor creates permissions.kdl" "true" \
+  "$([ -f "$PERM_FILE" ] && echo true || echo false)"
+PERM_CONTENT=$(cat "$PERM_FILE")
+contains "doctor permissions use file: prefix" "file:$FAKE_WASM" "$PERM_CONTENT"
+
 # doctor idempotent: run again, should say "ok" / "already"
 CONFIG_BEFORE=$(cat "$MOCK_DR_HOME/.config/zellij/config.kdl")
 out2=$(HOME="$MOCK_DR_HOME" ZELLIGENT_PLUGIN_SRC="$FAKE_WASM" \

--- a/zelligent.sh
+++ b/zelligent.sh
@@ -126,17 +126,18 @@ KDL
   mkdir -p "$(dirname "$PERM_FILE")"
   touch "$PERM_FILE"
 
-  if grep -qF "$PLUGIN_PATH" "$PERM_FILE"; then
+  PLUGIN_LOCATION="file:$PLUGIN_PATH"
+  if grep -qF "$PLUGIN_LOCATION" "$PERM_FILE"; then
     echo "  permissions: ok"
   else
     cat >> "$PERM_FILE" <<PERMS
-"$PLUGIN_PATH" {
+"$PLUGIN_LOCATION" {
     ChangeApplicationState
     ReadApplicationState
     RunCommands
 }
 PERMS
-    echo "  permissions: granted for $PLUGIN_PATH"
+    echo "  permissions: granted for $PLUGIN_LOCATION"
   fi
 
   if [ "$ERRORS" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- The Zellij config keybinding registers the plugin as `file:/path/to/plugin.wasm`
- Zellij uses this full location string (including the `file:` prefix) as the key in its permissions cache
- `zelligent doctor` was writing the permissions.kdl entry as just `/path/to/plugin.wasm` — without the `file:` prefix
- Since the keys never matched, Zellij prompted "Waiting for permissions" on every launch

Fix: write `file:$PLUGIN_PATH` in permissions.kdl so it matches the config keybinding location string.

## Test plan

- [x] New test: `doctor permissions use file: prefix`
- [x] All 86 tests pass
- [ ] `brew upgrade zelligent && zelligent doctor` no longer re-prompts for permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)