### PR TITLE
Revert file: prefix, show errors in Loading mode

### DIFF
--- a/plugin/src/main.rs
+++ b/plugin/src/main.rs
@@ -560,7 +560,11 @@ impl ZellijPlugin for State {
             Mode::Loading => {
                 ui::render_header("loading...", cols);
                 println!();
-                println!("  Waiting for permissions...");
+                if self.status_is_error {
+                    ui::render_status(&self.status_message, self.status_is_error);
+                } else {
+                    println!("  Waiting for permissions...");
+                }
             }
             Mode::BrowseWorktrees => {
                 ui::render_header(&self.repo_name, cols);

--- a/test.sh
+++ b/test.sh
@@ -31,6 +31,15 @@ contains() {
   fi
 }
 
+not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    fail "$desc (expected NOT to contain: '$needle')"
+  else
+    pass "$desc"
+  fi
+}
+
 excludes() {
   local desc="$1" needle="$2" haystack="$3"
   if echo "$haystack" | grep -qF "$needle"; then
@@ -290,7 +299,8 @@ fi
 check "doctor creates permissions.kdl" "true" \
   "$([ -f "$PERM_FILE" ] && echo true || echo false)"
 PERM_CONTENT=$(cat "$PERM_FILE")
-contains "doctor permissions use file: prefix" "file:$FAKE_WASM" "$PERM_CONTENT"
+contains "doctor permissions use bare path" "$FAKE_WASM" "$PERM_CONTENT"
+not_contains "doctor permissions omit file: prefix" "file:$FAKE_WASM" "$PERM_CONTENT"
 
 # doctor idempotent: run again, should say "ok" / "already"
 CONFIG_BEFORE=$(cat "$MOCK_DR_HOME/.config/zellij/config.kdl")

--- a/zelligent.sh
+++ b/zelligent.sh
@@ -126,18 +126,17 @@ KDL
   mkdir -p "$(dirname "$PERM_FILE")"
   touch "$PERM_FILE"
 
-  PLUGIN_LOCATION="file:$PLUGIN_PATH"
-  if grep -qF "$PLUGIN_LOCATION" "$PERM_FILE"; then
+  if grep -qF "$PLUGIN_PATH" "$PERM_FILE"; then
     echo "  permissions: ok"
   else
     cat >> "$PERM_FILE" <<PERMS
-"$PLUGIN_LOCATION" {
+"$PLUGIN_PATH" {
     ChangeApplicationState
     ReadApplicationState
     RunCommands
 }
 PERMS
-    echo "  permissions: granted for $PLUGIN_LOCATION"
+    echo "  permissions: granted for $PLUGIN_PATH"
   fi
 
   if [ "$ERRORS" -ne 0 ]; then


### PR DESCRIPTION
## Summary

- **Revert `file:` prefix in permissions.kdl**: Zellij's `PermissionCache` uses `RunPluginLocation::to_string()` as the lookup key, which returns the bare path (e.g. `/opt/homebrew/share/zelligent/zelligent-plugin.wasm`) — NOT `file:/path`. The v0.1.6 "fix" wrote entries with `file:` that never matched, so Zellij kept prompting.
- **Show errors in Loading mode**: When the plugin gets past permissions but `show-repo` fails, the mode stays `Loading` and the render showed "Waiting for permissions..." hiding the actual error. Now it shows the real error message.
- **Add `not_contains` test helper** and test that permissions.kdl entries use bare paths.

## Test plan

- [x] 87 shell tests pass
- [x] Plugin compiles (dev-install)
- [ ] On test machine: `brew upgrade zelligent && zelligent doctor` → plugin loads without permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)