### PR TITLE
Skip exited sessions to prevent stale plugin resurrection

### DIFF
--- a/zelligent.sh
+++ b/zelligent.sh
@@ -178,7 +178,7 @@ if [ -z "$1" ]; then
     exit 0
   fi
 
-  if zellij list-sessions --no-formatting --short 2>/dev/null | grep -qxF "$REPO_NAME"; then
+  if zellij list-sessions --no-formatting 2>/dev/null | grep -v EXITED | grep -qF "$REPO_NAME"; then
     echo "Attaching to session '$REPO_NAME'..."
     exec zellij attach "$REPO_NAME"
   else
@@ -384,7 +384,7 @@ fi
 if [ -n "$ZELLIJ" ]; then
   echo "🪟 Opening tab '$SESSION_NAME'..."
   zellij action new-tab --layout "$LAYOUT" --name "$SESSION_NAME"
-elif zellij list-sessions --no-formatting --short 2>/dev/null | grep -qxF "$REPO_NAME"; then
+elif zellij list-sessions --no-formatting 2>/dev/null | grep -v EXITED | grep -qF "$REPO_NAME"; then
   echo "🪟 Attaching to session '$REPO_NAME', opening tab '$SESSION_NAME'..."
   ZELLIJ_SESSION_NAME="$REPO_NAME" zellij action new-tab --layout "$LAYOUT" --name "$SESSION_NAME"
   zellij attach "$REPO_NAME"


### PR DESCRIPTION
## Summary

- `zellij list-sessions --short` includes EXITED (resurrectable) sessions
- When zelligent found a matching exited session, it ran `zellij attach` which resurrected it — loading the **old cached plugin binary** from before the upgrade
- This was the root cause of "Waiting for permissions" after `brew upgrade`: the resurrected session used a stale plugin that had different permissions state
- Fix: filter out lines containing `EXITED` before checking for a matching session name

Both the no-args path and the spawn path are fixed.

## Test plan

- [x] 87 tests pass
- [ ] On test machine: `pkill -9 zellij && brew upgrade zelligent && zelligent doctor && cd <repo> && zelligent` → fresh session, no permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)