### PR TITLE
Fix plugin cwd in resurrected Zellij sessions

### DIFF
--- a/plugin/src/main.rs
+++ b/plugin/src/main.rs
@@ -59,6 +59,7 @@ pub struct State {
     pub status_message: String,
     pub status_is_error: bool,
     pub zelligent_path: String,
+    pub initial_cwd: PathBuf,
     pub tabs: Vec<TabInfo>,
     /// Flipped to `true` after the first successful worktree list load.
     /// Auto-selection of the active tab's worktree only happens before this
@@ -140,8 +141,10 @@ impl State {
     }
 
     fn fire_git_toplevel(&self) {
-        run_command(
+        run_command_with_env_variables_and_cwd(
             &[&self.zelligent_path, "show-repo"],
+            BTreeMap::new(),
+            self.initial_cwd.clone(),
             Self::ctx(CMD_GIT_TOPLEVEL),
         );
     }
@@ -487,6 +490,8 @@ impl ZellijPlugin for State {
             .get("zelligent_path")
             .cloned()
             .unwrap_or_else(|| "zelligent".to_string());
+
+        self.initial_cwd = get_plugin_ids().initial_cwd;
 
         request_permission(&[
             PermissionType::RunCommands,


### PR DESCRIPTION
## Summary

Root cause of the "Waiting for permissions" / "not a git repo" bug in resurrected sessions:

- The plugin calls `zelligent show-repo` (which runs `git rev-parse --show-toplevel`) to discover the repo
- It used `run_command` with no explicit cwd, so Zellij ran it in the plugin's default working directory
- In a **resurrected session**, that default cwd is wherever `zellij` was relaunched from — often not inside a git repo
- `show-repo` failed, but the Loading mode render showed "Waiting for permissions..." (fixed in v0.1.7 to show the real error)

Fix: capture `get_plugin_ids().initial_cwd` on load and pass it to `run_command_with_env_variables_and_cwd` for the `show-repo` call.

## Test plan

- [x] Plugin compiles and installs via dev-install
- [ ] Resurrect an exited session, press Ctrl-y → plugin loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)