### PR TITLE
Set serialization_interval 5 in doctor, document session resurrection

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ These are Zellij's default keybindings:
 | Close tab | `Ctrl-t x` |
 | Switch panes | `Ctrl-p` + arrow keys |
 
+## Session resurrection
+
+Zellij automatically saves your session layout periodically and restores it when you reattach. By default it snapshots every 60 seconds, which means tabs you closed in the last minute can reappear after a restart.
+
+`zelligent doctor` sets `serialization_interval 5` in your Zellij config so snapshots are taken every 5 seconds. This keeps the saved state close to what you actually see, so closed tabs stay closed after resurrection.
+
 ## Installing from source
 
 ```bash

--- a/zelligent.sh
+++ b/zelligent.sh
@@ -117,7 +117,15 @@ KDL
     fi
   fi
 
-  # 5. Grant plugin permissions
+  # 5. Serialization interval (keeps session snapshots fresh for resurrection)
+  if grep -qF 'serialization_interval' "$CONFIG"; then
+    echo "  serialization_interval: ok"
+  else
+    echo 'serialization_interval 5' >> "$CONFIG"
+    echo "  serialization_interval: set to 5s in $CONFIG"
+  fi
+
+  # 6. Grant plugin permissions
   if [ "$(uname)" = "Darwin" ]; then
     PERM_FILE="$HOME/Library/Caches/org.Zellij-Contributors.Zellij/permissions.kdl"
   else


### PR DESCRIPTION
## Summary
- `zelligent doctor` now sets `serialization_interval 5` in Zellij config so session snapshots stay fresh
- Added README section explaining session resurrection and why this matters

## Context
Zellij snapshots sessions every 60s by default. If a user closes a tab and exits within that window, the stale tab reappears on resurrection. A 5s interval practically eliminates this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)