### PR TITLE
Fix doctor falsely detecting commented-out config values

### DIFF
--- a/zelligent.sh
+++ b/zelligent.sh
@@ -111,7 +111,7 @@ if [ "$1" = "doctor" ]; then
   mkdir -p "$(dirname "$CONFIG")"
   touch "$CONFIG"
 
-  if grep -qF 'zelligent-plugin.wasm' "$CONFIG"; then
+  if grep -v '^\s*//' "$CONFIG" | grep -qF 'zelligent-plugin.wasm'; then
     echo "  keybinding: ok ($CONFIG)"
   else
     cat >> "$CONFIG" <<KDL
@@ -132,7 +132,7 @@ KDL
   fi
 
   if [ "$(uname)" = "Darwin" ]; then
-    if grep -qF 'copy_command' "$CONFIG"; then
+    if grep -v '^\s*//' "$CONFIG" | grep -qF 'copy_command'; then
       echo "  copy_command: ok"
     else
       echo 'copy_command "pbcopy"' >> "$CONFIG"
@@ -141,7 +141,7 @@ KDL
   fi
 
   # 5. Serialization interval (keeps session snapshots fresh for resurrection)
-  if grep -qF 'serialization_interval' "$CONFIG"; then
+  if grep -v '^\s*//' "$CONFIG" | grep -qF 'serialization_interval'; then
     echo "  serialization_interval: ok"
   else
     echo 'serialization_interval 5' >> "$CONFIG"


### PR DESCRIPTION
## Summary
- `zelligent doctor` grep checks matched KDL comments (`// serialization_interval 10000`) as active config
- This prevented `serialization_interval 5` from being added, causing sessions to not serialize before quick Ctrl-Q exits
- Sessions without a saved layout cannot be resurrected, so `zelligent` creates a fresh session instead
- Fix: filter out comment lines (`grep -v '^\s*//'`) before checking for config values

## Test plan
- [x] All 114 existing tests pass
- [ ] Run `zelligent doctor` on a config with only commented `serialization_interval` — verify it adds the real value
- [ ] Create session, Ctrl-Q quickly, run `zelligent` again — verify session resurrects

🤖 Generated with [Claude Code](https://claude.com/claude-code)