### PR TITLE
Add tab bar notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,13 @@ Zellij automatically saves your session layout periodically and restores it when
 
 ```bash
 git clone https://github.com/pcomans/zelligent.git
+git clone https://github.com/zellij-org/zellij.git
 cd zelligent
-PATH="$HOME/.rustup/toolchains/stable-$(rustc -vV | grep host | cut -d' ' -f2)/bin:$PATH" bash dev-install.sh
+ZELLIGENT_ZELLIJ_SRC=../zellij \
+  PATH="$HOME/.rustup/toolchains/stable-$(rustc -vV | grep host | cut -d' ' -f2)/bin:$PATH" \
+  bash dev-install.sh
 ```
 
 Requires [Rust via rustup](https://rustup.rs) with the `wasm32-wasip1` target (`rustup target add wasm32-wasip1`).
+
+`ZELLIGENT_ZELLIJ_SRC` must point to a local [Zellij](https://github.com/zellij-org/zellij) checkout (main branch). The dev-install script builds Zellij from source and installs it alongside zelligent.

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -50,43 +50,26 @@ rm -rf "$PLUGIN_DST"
 cp -R "$PLUGIN_SRC" "$PLUGIN_DST"
 echo "Installed Claude plugin to $PLUGIN_DST"
 
-# Optionally build and install a patched Zellij from local source
-if [ -n "$ZELLIGENT_ZELLIJ_SRC" ]; then
-  if [ ! -d "$ZELLIGENT_ZELLIJ_SRC" ]; then
-    echo "Error: ZELLIGENT_ZELLIJ_SRC=$ZELLIGENT_ZELLIJ_SRC does not exist" >&2
-    exit 1
-  fi
-  # Uninstall Homebrew Zellij to avoid PATH conflicts, if Homebrew is available
-  if command -v brew >/dev/null 2>&1; then
-    if brew list zellij &>/dev/null; then
-      echo "Uninstalling Homebrew Zellij to avoid PATH conflicts..."
-      brew uninstall zellij
-    fi
-  fi
-  echo "Building Zellij from $ZELLIGENT_ZELLIJ_SRC..."
-  cargo build --release --manifest-path "$ZELLIGENT_ZELLIJ_SRC/Cargo.toml"
-  cp "$ZELLIGENT_ZELLIJ_SRC/target/release/zellij" "$INSTALL_DIR/zellij"
-  echo "Installed patched Zellij to $INSTALL_DIR/zellij"
+# Build and install Zellij from source (main branch)
+# Default to sibling ../zellij directory, override with ZELLIGENT_ZELLIJ_SRC
+ZELLIJ_SRC="${ZELLIGENT_ZELLIJ_SRC:?Set ZELLIGENT_ZELLIJ_SRC to your local Zellij checkout}"
+if [ ! -d "$ZELLIJ_SRC" ]; then
+  echo "Error: Zellij source not found at $ZELLIJ_SRC" >&2
+  echo "Either clone https://github.com/zellij-org/zellij next to the zelligent repo," >&2
+  echo "or set ZELLIGENT_ZELLIJ_SRC to your local checkout." >&2
+  exit 1
 fi
-
-# Optionally build and install a patched Zellij from local source
-if [ -n "$ZELLIGENT_ZELLIJ_SRC" ]; then
-  if [ ! -d "$ZELLIGENT_ZELLIJ_SRC" ]; then
-    echo "Error: ZELLIGENT_ZELLIJ_SRC=$ZELLIGENT_ZELLIJ_SRC does not exist" >&2
-    exit 1
+# Uninstall Homebrew Zellij to avoid PATH conflicts
+if command -v brew >/dev/null 2>&1; then
+  if brew list zellij &>/dev/null; then
+    echo "Uninstalling Homebrew Zellij to avoid PATH conflicts..."
+    brew uninstall zellij
   fi
-  # Uninstall Homebrew Zellij to avoid PATH conflicts
-  if command -v brew >/dev/null 2>&1; then
-    if brew list zellij &>/dev/null; then
-      echo "Uninstalling Homebrew Zellij to avoid PATH conflicts..."
-      brew uninstall zellij
-    fi
-  fi
-  echo "Building Zellij from $ZELLIGENT_ZELLIJ_SRC..."
-  cargo build --release --manifest-path "$ZELLIGENT_ZELLIJ_SRC/Cargo.toml"
-  cp "$ZELLIGENT_ZELLIJ_SRC/target/release/zellij" "$INSTALL_DIR/zellij"
-  echo "Installed patched Zellij to $INSTALL_DIR/zellij"
 fi
+echo "Building Zellij from $ZELLIJ_SRC..."
+cargo build --release --manifest-path "$ZELLIJ_SRC/Cargo.toml"
+cp "$ZELLIJ_SRC/target/release/zellij" "$INSTALL_DIR/zellij"
+echo "Installed Zellij to $INSTALL_DIR/zellij"
 
 # Update Zellij config to point at the dev plugin path
 CONFIG="$HOME/.config/zellij/config.kdl"

--- a/plugin/Cargo.lock
+++ b/plugin/Cargo.lock
@@ -57,165 +57,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener 2.5.3",
+ "event-listener",
  "futures-core",
 ]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.6.1",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite 2.6.1",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.6.1",
- "parking",
- "polling 3.11.0",
- "rustix 1.1.3",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.1",
- "futures-lite 2.6.1",
- "rustix 1.1.3",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.3",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 2.6.1",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "atomic"
@@ -225,12 +75,6 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -313,19 +157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite 2.6.1",
- "piper",
 ]
 
 [[package]]
@@ -542,6 +373,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio 1.1.1",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,27 +596,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
- "pin-project-lite",
-]
 
 [[package]]
 name = "fancy-regex"
@@ -843,15 +684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,35 +711,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand 2.3.0",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "futures-task"
+name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "generic-array"
@@ -962,18 +769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,15 +788,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -1035,15 +821,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "http"
@@ -1278,15 +1055,17 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "1.2.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
 dependencies = [
- "cfg-if",
+ "doctest-file",
+ "futures-core",
  "libc",
- "rustc_version",
- "to_method",
- "winapi",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1312,19 +1091,19 @@ version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel",
  "castaway",
  "crossbeam-utils",
  "curl",
  "curl-sys",
  "encoding_rs",
- "event-listener 2.5.3",
- "futures-lite 1.13.0",
+ "event-listener",
+ "futures-lite",
  "http",
  "log",
  "mime",
  "once_cell",
- "polling 2.8.0",
+ "polling",
  "slab",
  "sluice",
  "tracing",
@@ -1387,15 +1166,6 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1493,9 +1263,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "log-mdc"
@@ -1635,6 +1402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1644,12 +1412,6 @@ name = "mock_instant"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "names"
@@ -1872,16 +1634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.13.0",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,23 +1712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand 2.3.0",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,20 +1734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.5.2",
- "pin-project-lite",
- "rustix 1.1.3",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,16 +1749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2094,28 +1805,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease 0.1.25",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,15 +1815,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -2181,6 +1861,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -2250,25 +1936,6 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
-
-[[package]]
-name = "rmp"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
-dependencies = [
- "rmp",
- "serde",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -2427,6 +2094,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.1.1",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,7 +2138,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel",
  "futures-core",
  "futures-io",
 ]
@@ -2516,20 +2194,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.20.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2776,12 +2454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "to_method"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
-
-[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,7 +2462,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.1.1",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2807,6 +2478,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2932,12 +2628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,20 +2723,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3110,16 +2786,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3195,16 +2861,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
+name = "widestring"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -3303,6 +2963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3547,7 +3216,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.13.0",
- "prettyplease 0.2.37",
+ "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -3561,7 +3230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease 0.2.37",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3645,9 +3314,8 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d91b67a39412232f192872ebff2f84e317fbed8402f989f6b20e57fd07d427b"
+version = "0.44.0"
+source = "git+https://github.com/zellij-org/zellij?branch=main#903cdf5d32476a8d6cc208d2c418a1f2c67e5a53"
 dependencies = [
  "clap",
  "prost",
@@ -3660,12 +3328,10 @@ dependencies = [
 
 [[package]]
 name = "zellij-utils"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cac29b8bd52be339e67e1b9c439fff5e56dfe83c493757c2879772d884a6123"
+version = "0.44.0"
+source = "git+https://github.com/zellij-org/zellij?branch=main#903cdf5d32476a8d6cc208d2c418a1f2c67e5a53"
 dependencies = [
  "anyhow",
- "async-std",
  "backtrace",
  "bitflags 2.11.0",
  "clap",
@@ -3673,6 +3339,7 @@ dependencies = [
  "colored",
  "colorsys",
  "crossbeam",
+ "crossterm",
  "directories",
  "humantime",
  "include_dir",
@@ -3688,8 +3355,6 @@ dependencies = [
  "notify",
  "percent-encoding",
  "prost",
- "prost-build",
- "rmp-serde",
  "serde",
  "serde_json",
  "sha2",
@@ -3702,9 +3367,12 @@ dependencies = [
  "termwiz",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "unicode-width",
  "url",
  "uuid",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -12,7 +12,7 @@ name = "zelligent-plugin"
 path = "src/main.rs"
 
 [dependencies]
-zellij-tile = "0.43"
+zellij-tile = { git = "https://github.com/zellij-org/zellij", branch = "main" }
 
 # Dev-deps are only needed for host-side tests/snapshots and are not used in the wasm release build.
 [dev-dependencies]

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -156,6 +156,39 @@ pub fn parse_branches(output: &str) -> Vec<String> {
         .collect()
 }
 
+/// Status prefixes used in tab bar names.
+const STATUS_PREFIX_NEEDS_INPUT: &str = "🟡 ";
+const STATUS_PREFIX_DONE: &str = "✅ ";
+
+/// All known status prefixes, used for stripping.
+const STATUS_PREFIXES: &[&str] = &[STATUS_PREFIX_NEEDS_INPUT, STATUS_PREFIX_DONE];
+
+/// Build the display name for a tab in the tab bar, with status prefix.
+pub fn tab_bar_display_name(tab_name: &str, status: &AgentStatus) -> String {
+    match status {
+        AgentStatus::NeedsInput => format!("{STATUS_PREFIX_NEEDS_INPUT}{tab_name}"),
+        AgentStatus::Done => format!("{STATUS_PREFIX_DONE}{tab_name}"),
+        // Working and Idle: restore original name (no prefix)
+        _ => tab_name.to_string(),
+    }
+}
+
+/// Check if a (possibly prefixed) tab name matches an original branch name.
+pub fn tab_name_matches_original(display_name: &str, original: &str) -> bool {
+    STATUS_PREFIXES
+        .iter()
+        .any(|prefix| display_name == format!("{prefix}{original}"))
+}
+
+/// Strip a status prefix from a tab name, returning the original name.
+/// Returns `None` if the name has no status prefix.
+pub fn strip_status_prefix(name: &str) -> Option<String> {
+    STATUS_PREFIXES
+        .iter()
+        .find(|prefix| name.starts_with(*prefix))
+        .map(|prefix| name[prefix.len()..].to_string())
+}
+
 /// Wrapping navigation: move `current` by `delta` within `[0, len)`, wrapping around.
 pub fn wrap_navigate(current: usize, len: usize, delta: isize) -> usize {
     if len == 0 {
@@ -242,16 +275,16 @@ impl State {
             Action::Spawn(branch) => self.fire_spawn(branch),
             Action::Remove(branch) => self.fire_remove(branch),
             Action::CloseTabAndRefresh { tab_name, return_to } => {
-                go_to_tab_name(tab_name);
+                go_to_tab_name(&self.actual_tab_name(tab_name));
                 close_focused_tab();
                 if let Some(name) = return_to {
-                    go_to_tab_name(name);
+                    go_to_tab_name(&self.actual_tab_name(name));
                 }
                 self.fire_list_worktrees();
                 self.fire_git_branches();
             }
             Action::SwitchToTab(tab_name) => {
-                go_to_tab_name(tab_name);
+                go_to_tab_name(&self.actual_tab_name(tab_name));
                 close_self();
             }
             Action::Refresh => {
@@ -264,7 +297,7 @@ impl State {
                 self.fire_git_branches();
             }
             Action::DumpLayout => {
-                dump_session_layout();
+                let _ = dump_session_layout();
             }
             Action::NukeSession => {
                 // The handler already verified session_name is Some.
@@ -274,6 +307,9 @@ impl State {
                 }
             }
             Action::Notify { tab_name, status } => {
+                // Sync tab bar to reflect current agent_statuses
+                self.sync_tab_bar_names();
+
                 // macOS-only: osascript and afplay. On Linux, use notify-send/paplay.
                 let body = match status {
                     AgentStatus::NeedsInput => format!("{tab_name} needs input"),
@@ -303,7 +339,50 @@ impl State {
         }
     }
 
+    /// Find a tab by its original (branch) name. Checks both the exact name
+    /// and prefixed variants (e.g., "🟡 feat-a") since we may have renamed it.
+    pub fn find_tab(&self, tab_name: &str) -> Option<&TabInfo> {
+        self.tabs
+            .iter()
+            .find(|t| t.name == tab_name || tab_name_matches_original(&t.name, tab_name))
+    }
+
+    /// Find a tab's ID by its original (branch) name.
+    pub fn find_tab_id(&self, tab_name: &str) -> Option<usize> {
+        self.find_tab(tab_name).map(|t| t.tab_id)
+    }
+
+    /// Get the actual display name of a tab (which may have a status prefix).
+    pub fn actual_tab_name(&self, tab_name: &str) -> String {
+        self.find_tab(tab_name)
+            .map(|t| t.name.clone())
+            .unwrap_or_else(|| tab_name.to_string())
+    }
+
+    /// Sync all tab bar names to match current `agent_statuses`.
+    /// For each tab, compute the expected display name and rename if it differs.
+    fn sync_tab_bar_names(&self) {
+        for tab in &self.tabs {
+            let original = strip_status_prefix(&tab.name).unwrap_or_else(|| tab.name.clone());
+            let status = self.agent_statuses.get(&original).copied().unwrap_or(AgentStatus::Idle);
+            let expected = tab_bar_display_name(&original, &status);
+            if tab.name != expected {
+                rename_tab_with_id(tab.tab_id as u64, &expected);
+            }
+        }
+    }
+
     // --- Pure state handlers (no zellij calls, fully testable) ---
+
+    /// Clear the agent status for whichever tab is currently active.
+    /// Called on TabUpdate so that focusing a tab dismisses its notification.
+    pub fn clear_notification_for_active_tab(&mut self) {
+        if let Some(active) = self.tabs.iter().find(|t| t.active) {
+            let original = strip_status_prefix(&active.name)
+                .unwrap_or_else(|| active.name.clone());
+            self.agent_statuses.remove(&original);
+        }
+    }
 
     pub fn handle_git_toplevel(&mut self, exit_code: Option<i32>, stdout: &[u8], stderr: &[u8]) -> Action {
         if exit_code != Some(0) {
@@ -426,7 +505,7 @@ impl State {
     /// Check whether a tab with the given branch's name exists.
     pub fn has_tab_for_branch(&self, branch: &str) -> bool {
         let tab_name = Self::tab_name_for_branch(branch);
-        self.tabs.iter().any(|t| t.name == tab_name)
+        self.tabs.iter().any(|t| t.name == tab_name || tab_name_matches_original(&t.name, &tab_name))
     }
 
     /// Switch to an existing tab for the branch, or spawn a new one.
@@ -573,18 +652,14 @@ impl State {
             Some("Stop") => AgentStatus::Done,
             _ => return Action::None,
         };
-        // Ignore status updates for unknown tabs
-        if !self.tabs.iter().any(|t| t.name == tab_name) {
+        // Ignore status updates for unknown tabs — check both original and
+        // prefixed names since we may have renamed the tab already.
+        if !self.find_tab_id(&tab_name).is_some() {
             return Action::None;
         }
         self.agent_statuses.insert(tab_name.clone(), status);
-        // TODO: consider suppressing notifications when the tab is active
-        match status {
-            AgentStatus::NeedsInput | AgentStatus::Done => {
-                Action::Notify { tab_name, status }
-            }
-            _ => Action::None,
-        }
+        // All status changes update the tab bar name (Working clears the prefix)
+        Action::Notify { tab_name, status }
     }
 
     pub fn handle_key_not_git_repo(&mut self, key: &KeyWithModifier) -> Action {
@@ -720,6 +795,9 @@ impl ZellijPlugin for State {
                         self.selected_index = idx;
                     }
                 }
+                // Clear notification for the active tab (user is looking at it)
+                self.clear_notification_for_active_tab();
+                self.sync_tab_bar_names();
                 Action::None
             }
             Event::Key(key) => {
@@ -1304,6 +1382,9 @@ mod tests {
             display_area_columns: 0,
             selectable_tiled_panes_count: 0,
             selectable_floating_panes_count: 0,
+            tab_id: 0,
+            has_bell_notification: false,
+            is_flashing_bell: false,
         }
     }
 
@@ -1574,20 +1655,20 @@ mod tests {
     }
 
     #[test]
-    fn pipe_start_sets_working_no_notify() {
+    fn pipe_start_sets_working_and_notifies() {
         let mut s = State::default();
         s.tabs = vec![make_tab("feat-a", false)];
         let action = s.handle_pipe(&pipe_msg("zelligent-status", &[("tab", "feat-a"), ("event", "Start")]));
-        assert_eq!(action, Action::None);
+        assert_eq!(action, Action::Notify { tab_name: "feat-a".into(), status: AgentStatus::Working });
         assert_eq!(s.agent_statuses.get("feat-a"), Some(&AgentStatus::Working));
     }
 
     #[test]
-    fn pipe_user_prompt_submit_sets_working() {
+    fn pipe_user_prompt_submit_sets_working_and_notifies() {
         let mut s = State::default();
         s.tabs = vec![make_tab("feat-a", false)];
         let action = s.handle_pipe(&pipe_msg("zelligent-status", &[("tab", "feat-a"), ("event", "UserPromptSubmit")]));
-        assert_eq!(action, Action::None);
+        assert_eq!(action, Action::Notify { tab_name: "feat-a".into(), status: AgentStatus::Working });
         assert_eq!(s.agent_statuses.get("feat-a"), Some(&AgentStatus::Working));
     }
 
@@ -1643,5 +1724,136 @@ mod tests {
         let action = s.handle_pipe(&pipe_msg("zelligent-status", &[("tab", "unknown-tab"), ("event", "Stop")]));
         assert_eq!(action, Action::None);
         assert_eq!(s.agent_statuses.get("unknown-tab"), None);
+    }
+
+    // --- tab_bar_display_name tests ---
+
+    #[test]
+    fn tab_bar_display_name_needs_input() {
+        assert_eq!(tab_bar_display_name("feat-a", &AgentStatus::NeedsInput), "🟡 feat-a");
+    }
+
+    #[test]
+    fn tab_bar_display_name_done() {
+        assert_eq!(tab_bar_display_name("feat-a", &AgentStatus::Done), "✅ feat-a");
+    }
+
+    #[test]
+    fn tab_bar_display_name_working_clears_prefix() {
+        assert_eq!(tab_bar_display_name("feat-a", &AgentStatus::Working), "feat-a");
+    }
+
+    #[test]
+    fn tab_bar_display_name_idle_clears_prefix() {
+        assert_eq!(tab_bar_display_name("feat-a", &AgentStatus::Idle), "feat-a");
+    }
+
+    #[test]
+    fn tab_name_matches_original_with_prefix() {
+        assert!(tab_name_matches_original("🟡 feat-a", "feat-a"));
+        assert!(tab_name_matches_original("✅ feat-a", "feat-a"));
+    }
+
+    #[test]
+    fn tab_name_matches_original_no_prefix() {
+        assert!(!tab_name_matches_original("feat-a", "feat-a"));
+        assert!(!tab_name_matches_original("feat-b", "feat-a"));
+    }
+
+    #[test]
+    fn find_tab_with_prefixed_name() {
+        let mut s = State::default();
+        let mut tab = make_tab("🟡 feat-a", false);
+        tab.tab_id = 42;
+        s.tabs = vec![tab];
+        assert_eq!(s.find_tab_id("feat-a"), Some(42));
+    }
+
+    #[test]
+    fn pipe_recognizes_prefixed_tab() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("🟡 feat-a", false)];
+        let action = s.handle_pipe(&pipe_msg("zelligent-status", &[("tab", "feat-a"), ("event", "Stop")]));
+        assert_eq!(action, Action::Notify { tab_name: "feat-a".into(), status: AgentStatus::Done });
+    }
+
+    // --- strip_status_prefix tests ---
+
+    #[test]
+    fn strip_status_prefix_with_needs_input() {
+        assert_eq!(strip_status_prefix("🟡 feat-a"), Some("feat-a".into()));
+    }
+
+    #[test]
+    fn strip_status_prefix_with_done() {
+        assert_eq!(strip_status_prefix("✅ feat-a"), Some("feat-a".into()));
+    }
+
+    #[test]
+    fn strip_status_prefix_no_prefix() {
+        assert_eq!(strip_status_prefix("feat-a"), None);
+    }
+
+    // --- clear_active_tab_notification tests (state-only, no zellij calls) ---
+
+    #[test]
+    fn has_tab_for_branch_finds_prefixed_tab() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("🟡 feat-a", false)];
+        assert!(s.has_tab_for_branch("feat-a"));
+    }
+
+    #[test]
+    fn actual_tab_name_returns_prefixed_name() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("🟡 feat-a", false)];
+        assert_eq!(s.actual_tab_name("feat-a"), "🟡 feat-a");
+    }
+
+    #[test]
+    fn actual_tab_name_returns_original_when_no_prefix() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("feat-a", false)];
+        assert_eq!(s.actual_tab_name("feat-a"), "feat-a");
+    }
+
+    #[test]
+    fn actual_tab_name_returns_input_when_tab_not_found() {
+        let s = State::default();
+        assert_eq!(s.actual_tab_name("missing"), "missing");
+    }
+
+    // --- clear_notification_for_active_tab tests ---
+
+    #[test]
+    fn clear_notification_removes_status_for_active_tab() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("🟡 feat-a", true)];
+        s.agent_statuses.insert("feat-a".into(), AgentStatus::NeedsInput);
+        s.clear_notification_for_active_tab();
+        assert_eq!(s.agent_statuses.get("feat-a"), None);
+    }
+
+    #[test]
+    fn clear_notification_ignores_inactive_tabs() {
+        let mut s = State::default();
+        s.tabs = vec![
+            make_tab("🟡 feat-a", false),
+            make_tab("feat-b", true),
+        ];
+        s.agent_statuses.insert("feat-a".into(), AgentStatus::NeedsInput);
+        s.clear_notification_for_active_tab();
+        // feat-a is not active, so its status should remain
+        assert_eq!(s.agent_statuses.get("feat-a"), Some(&AgentStatus::NeedsInput));
+    }
+
+    #[test]
+    fn clear_notification_no_op_when_active_tab_has_no_status() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("feat-b", true)];
+        s.agent_statuses.insert("feat-a".into(), AgentStatus::Done);
+        s.clear_notification_for_active_tab();
+        // feat-a's status should be untouched
+        assert_eq!(s.agent_statuses.get("feat-a"), Some(&AgentStatus::Done));
     }
 }

--- a/plugin/tests/common/mod.rs
+++ b/plugin/tests/common/mod.rs
@@ -36,6 +36,9 @@ pub fn make_tab_info(name: &str, active: bool) -> TabInfo {
         display_area_columns: 0,
         selectable_tiled_panes_count: 0,
         selectable_floating_panes_count: 0,
+        tab_id: 0,
+        has_bell_notification: false,
+        is_flashing_bell: false,
     }
 }
 


### PR DESCRIPTION
## Summary
- When agent status changes, the tab name in Zellij's tab bar gets an emoji prefix: 🟡 (needs input) or ✅ (done)
- Focusing the tab automatically clears the notification
- Both the plugin pane (ctrl+y) dots and tab bar names are driven from the single `agent_statuses` state — they can't get out of sync
- Updates `dev-install.sh` to build Zellij from source (requires `ZELLIGENT_ZELLIJ_SRC` env var pointing to a local Zellij checkout on main)
- Bumps `zellij-tile` dependency to Zellij main (for `rename_tab_with_id` and `tab_id` in `TabInfo`)

## Test plan
- [x] All 130 tests pass (109 lib + 21 snapshots)
- [x] WASM plugin builds successfully
- [ ] Manual: spawn agents, verify emoji appears in tab bar on status change
- [ ] Manual: switch to notified tab, verify emoji clears
- [ ] Manual: verify plugin pane dots stay in sync with tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)