### PR TITLE
fix(remove): close the worktree tab when running inside Zellij

### DIFF
--- a/docs/design-docs/worktree-lifecycle.md
+++ b/docs/design-docs/worktree-lifecycle.md
@@ -22,7 +22,8 @@
 2. **Validate ownership** — confirms the worktree is under `~/.zelligent/worktrees/<repo>/`
 3. **Run teardown hook** — if `.zelligent/teardown.sh` exists, runs it first. Aborts if it fails.
 4. **Remove worktree** — `git worktree remove <path>` (fails if uncommitted changes)
-5. **Print instructions** — reminds user to close the tab manually and notes the branch is preserved
+5. **Close the tab when running inside Zellij** — `zelligent` checks `$ZELLIJ`; if set, records the current tab via `zellij action current-tab-info`, switches to the worktree's tab via `zellij action go-to-tab-name <sanitized-branch>`, runs `zellij action close-tab`, then returns to the original tab. This stops the sidebar from showing the stale row as an orphaned "user tab". When invoked outside Zellij, prints a hint to close the tab manually instead.
+6. **Note the branch is preserved** — `git worktree remove` does not delete the local branch.
 
 ## Nuke (`zelligent nuke`)
 

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -531,6 +531,14 @@ impl State {
                 let tab_name = Self::tab_name_for_branch(&branch);
                 self.agent_statuses.remove(&tab_name);
                 let return_to = self.tabs.iter().find(|t| t.active).map(|t| t.name.clone());
+                // Drop the closed tab from our cache up front. The host fires
+                // a TabUpdate after the close completes, but the worktree-list
+                // refresh that follows races against it: if the worktree list
+                // lands first, recompute_sidebar_items still sees the closed
+                // tab in self.tabs, fails to match it to any worktree, and
+                // surfaces it as an orphaned "user tab" until TabUpdate
+                // catches up.
+                self.tabs.retain(|t| t.name != tab_name);
                 return Action::CloseTabAndRefresh {
                     tab_name,
                     return_to,
@@ -1834,6 +1842,14 @@ mod tests {
                 tab_name: "feat-a".into(),
                 return_to: Some("zelligent".into()),
             }
+        );
+        // The closed tab must be removed from our cached tab list immediately,
+        // so that any sidebar recompute triggered by the worktree-list refresh
+        // doesn't mislabel it as an orphaned "user tab" before the host's
+        // TabUpdate event catches up.
+        assert!(
+            s.tabs.iter().all(|t| t.name != "feat-a"),
+            "closed tab 'feat-a' should be dropped from self.tabs cache"
         );
     }
 

--- a/test.sh
+++ b/test.sh
@@ -937,6 +937,37 @@ out=$("$SCRIPT" remove "no-such-branch-$$" 2>&1); code=$?
 check "remove nonexistent branch exits non-zero" "1" "$code"
 contains "remove nonexistent branch: prints error" "no worktree found" "$out"
 
+# remove inside Zellij: closes the worktree's tab so the sidebar doesn't show
+# it as an orphaned "user tab"
+TEST_WT_INSIDE_BRANCH="test-inside-$$"
+TEST_WT_INSIDE_SESSION="${TEST_WT_INSIDE_BRANCH//\//-}"
+TEST_WT_INSIDE_DIR="$HOME/.zelligent/worktrees/$REPO_NAME/$TEST_WT_INSIDE_BRANCH"
+register_cleanup_worktree "$TEST_WT_INSIDE_DIR" "$TEST_WT_INSIDE_BRANCH"
+git -C "$REPO_ROOT" worktree add -b "$TEST_WT_INSIDE_BRANCH" "$TEST_WT_INSIDE_DIR" HEAD &>/dev/null
+# Mock zellij records its full argv to a log so we can verify the close
+MOCK_BIN_REMOVE=$(mktemp -d)
+REMOVE_LOG=$(mktemp)
+cat > "$MOCK_BIN_REMOVE/zellij" <<MOCK
+#!/bin/bash
+echo "zellij \$*" >> "$REMOVE_LOG"
+if [ "\$1" = "action" ] && [ "\$2" = "current-tab-info" ]; then
+  echo "name: origin-tab"
+  echo "id: 1"
+fi
+MOCK
+chmod +x "$MOCK_BIN_REMOVE/zellij"
+out=$(ZELLIJ=1 ZELLIJ_SESSION_NAME=fake PATH="$MOCK_BIN_REMOVE:$PATH" "$SCRIPT" remove "$TEST_WT_INSIDE_BRANCH" 2>&1); code=$?
+check "remove inside zellij exits 0" "0" "$code"
+contains "remove inside zellij: prints success" "Removed" "$out"
+ACTIONS=$(cat "$REMOVE_LOG")
+contains "remove inside zellij: queries current tab"  "action current-tab-info"                     "$ACTIONS"
+contains "remove inside zellij: switches to target"   "action go-to-tab-name $TEST_WT_INSIDE_SESSION" "$ACTIONS"
+contains "remove inside zellij: closes the tab"       "action close-tab"                              "$ACTIONS"
+contains "remove inside zellij: returns to origin"    "action go-to-tab-name origin-tab"             "$ACTIONS"
+excludes "remove inside zellij: no manual-close hint" "Close the '$TEST_WT_INSIDE_SESSION' tab manually" "$out"
+git -C "$REPO_ROOT" branch -D "$TEST_WT_INSIDE_BRANCH" &>/dev/null || true
+rm -rf "$MOCK_BIN_REMOVE" "$REMOVE_LOG"
+
 # remove refuses to act on non-zelligent-managed worktree (safety check)
 TEST_WT_UNMANAGED_BRANCH="test-unmanaged-$$"
 TEST_WT_UNMANAGED_DIR=$(mktemp -d)

--- a/test.sh
+++ b/test.sh
@@ -522,7 +522,7 @@ cat > "$MOCK_NOARGS_BIN_NONE/git" <<'MOCK'
 /usr/bin/git "$@"
 MOCK
 chmod +x "$MOCK_NOARGS_BIN_NONE/git"
-out=$(HOME="$MOCK_NOARGS_HOME_NONE" ZELLIGENT_PLUGIN_SRC="" PATH="$MOCK_NOARGS_BIN_NONE:/usr/bin:/bin" "$SCRIPT" 2>&1); code=$?
+out=$(ZELLIJ="" ZELLIJ_SESSION_NAME="" HOME="$MOCK_NOARGS_HOME_NONE" ZELLIGENT_PLUGIN_SRC="" PATH="$MOCK_NOARGS_BIN_NONE:/usr/bin:/bin" "$SCRIPT" 2>&1); code=$?
 check "no args without plugin exits non-zero" "1" "$code"
 contains "no args without plugin: suggests doctor" "zelligent doctor" "$out"
 rm -rf "$MOCK_NOARGS_BIN_NONE" "$MOCK_NOARGS_HOME_NONE"
@@ -967,6 +967,38 @@ contains "remove inside zellij: returns to origin"    "action go-to-tab-name ori
 excludes "remove inside zellij: no manual-close hint" "Close the '$TEST_WT_INSIDE_SESSION' tab manually" "$out"
 git -C "$REPO_ROOT" branch -D "$TEST_WT_INSIDE_BRANCH" &>/dev/null || true
 rm -rf "$MOCK_BIN_REMOVE" "$REMOVE_LOG"
+
+# remove inside Zellij: when go-to-tab-name fails (tab already gone), the
+# script should still exit 0 and skip the close-tab call instead of erroring
+TEST_WT_TABGONE_BRANCH="test-tabgone-$$"
+TEST_WT_TABGONE_DIR="$HOME/.zelligent/worktrees/$REPO_NAME/$TEST_WT_TABGONE_BRANCH"
+register_cleanup_worktree "$TEST_WT_TABGONE_DIR" "$TEST_WT_TABGONE_BRANCH"
+git -C "$REPO_ROOT" worktree add -b "$TEST_WT_TABGONE_BRANCH" "$TEST_WT_TABGONE_DIR" HEAD &>/dev/null
+MOCK_BIN_TABGONE=$(mktemp -d)
+TABGONE_LOG=$(mktemp)
+cat > "$MOCK_BIN_TABGONE/zellij" <<MOCK
+#!/bin/bash
+echo "zellij \$*" >> "$TABGONE_LOG"
+if [ "\$1" = "action" ] && [ "\$2" = "current-tab-info" ]; then
+  echo "name: origin-tab"
+  echo "id: 1"
+  exit 0
+fi
+# Simulate the worktree's tab having already been closed externally:
+# go-to-tab-name fails when the target tab no longer exists.
+if [ "\$1" = "action" ] && [ "\$2" = "go-to-tab-name" ] && [ "\$3" = "$TEST_WT_TABGONE_BRANCH" ]; then
+  exit 1
+fi
+exit 0
+MOCK
+chmod +x "$MOCK_BIN_TABGONE/zellij"
+out=$(ZELLIJ=1 ZELLIJ_SESSION_NAME=fake PATH="$MOCK_BIN_TABGONE:$PATH" "$SCRIPT" remove "$TEST_WT_TABGONE_BRANCH" 2>&1); code=$?
+check "remove inside zellij (tab already gone): still exits 0" "0" "$code"
+contains "remove inside zellij (tab already gone): prints success" "Removed" "$out"
+ACTIONS=$(cat "$TABGONE_LOG")
+excludes "remove inside zellij (tab already gone): skips close-tab" "action close-tab" "$ACTIONS"
+git -C "$REPO_ROOT" branch -D "$TEST_WT_TABGONE_BRANCH" &>/dev/null || true
+rm -rf "$MOCK_BIN_TABGONE" "$TABGONE_LOG"
 
 # remove refuses to act on non-zelligent-managed worktree (safety check)
 TEST_WT_UNMANAGED_BRANCH="test-unmanaged-$$"

--- a/zelligent.sh
+++ b/zelligent.sh
@@ -902,7 +902,21 @@ if [ "$1" = "remove" ]; then
     exit 1
   fi
   echo "✅ Removed worktree for '$BRANCH_NAME'"
-  echo "ℹ️  Close the '$SESSION_NAME' tab manually if still open."
+  # When running inside Zellij, also close the worktree's tab so the sidebar
+  # plugin doesn't show an orphaned tab labeled "user tab" (the worktree is
+  # gone but Zellij still holds the tab). Return the user to the tab they
+  # came from after closing.
+  if [ -n "$ZELLIJ" ] && command -v zellij &>/dev/null; then
+    ORIGIN_TAB=$(zellij action current-tab-info 2>/dev/null | awk -F': ' 'NR==1 && $1=="name" { print $2 }')
+    if zellij action go-to-tab-name "$SESSION_NAME" 2>/dev/null; then
+      zellij action close-tab 2>/dev/null || true
+      if [ -n "$ORIGIN_TAB" ] && [ "$ORIGIN_TAB" != "$SESSION_NAME" ]; then
+        zellij action go-to-tab-name "$ORIGIN_TAB" 2>/dev/null || true
+      fi
+    fi
+  else
+    echo "ℹ️  Close the '$SESSION_NAME' tab manually if still open."
+  fi
   echo "ℹ️  Local branch '$BRANCH_NAME' was not deleted."
   exit 0
 fi

--- a/zelligent.sh
+++ b/zelligent.sh
@@ -907,7 +907,11 @@ if [ "$1" = "remove" ]; then
   # gone but Zellij still holds the tab). Return the user to the tab they
   # came from after closing.
   if [ -n "$ZELLIJ" ] && command -v zellij &>/dev/null; then
-    ORIGIN_TAB=$(zellij action current-tab-info 2>/dev/null | awk -F': ' 'NR==1 && $1=="name" { print $2 }')
+    # Capture the full remainder of the `name:` line — tab names can be
+    # user-renamed (Ctrl-t r) to include `: `, in which case `-F': '` would
+    # truncate at the second separator. Use `sed` to strip only the leading
+    # `name: ` and keep everything else verbatim.
+    ORIGIN_TAB=$(zellij action current-tab-info 2>/dev/null | sed -n '1{s/^name: //p;}')
     if zellij action go-to-tab-name "$SESSION_NAME" 2>/dev/null; then
       zellij action close-tab 2>/dev/null || true
       if [ -n "$ORIGIN_TAB" ] && [ "$ORIGIN_TAB" != "$SESSION_NAME" ]; then


### PR DESCRIPTION
## Summary

`zelligent remove` invoked from inside a Zellij session now also closes the worktree's tab and returns focus to the previous tab. Previously the user had to close the tab by hand — or, if the worktree was removed via the sidebar's `d` keybinding, watched the row linger as an orphaned \"user tab\" until the next refresh.

Also includes a related plugin fix: `handle_remove_result` now drops the closed tab from `self.tabs` synchronously *before* emitting `CloseTabAndRefresh`. Without this, the worktree-list refresh that follows can race the host's `TabUpdate` event and `recompute_sidebar_items` mislabels the soon-to-be-closed tab as an orphaned \"user tab\" row.

## Changes

- **`zelligent.sh`** — when `\$ZELLIJ` is set, `remove` records the active tab via `zellij action current-tab-info`, switches to the worktree's tab, runs `close-tab`, then switches back to the origin. Outside Zellij the old manual-close hint is preserved.
- **`plugin/src/lib.rs`** — `handle_remove_result` retains-out the closed tab from `self.tabs` synchronously to win the refresh race.
- **`docs/design-docs/worktree-lifecycle.md`** — step 5 now describes the tab-close behavior; manual-close hint is documented as the outside-Zellij fallback.

## Test plan

- [x] New `test.sh` block: stubs zellij as a script that logs its argv, runs `zelligent remove` with `ZELLIJ=1`, and asserts the full action sequence: \`current-tab-info\` → \`go-to-tab-name <branch>\` → \`close-tab\` → \`go-to-tab-name <origin>\`. Also verifies no \"Close the … tab manually\" hint is printed.
- [x] New plugin assertion (in the existing remove-tab unit test) verifies that the closed tab's name is gone from \`self.tabs\` after \`handle_remove_result\`.
- [x] Baseline `bash test.sh` run passes locally (exit 0) on these changes. Note: my local environment has a concurrent test-runner that occasionally SIGKILLs in-flight runs and stomps on shared \`.zelligent/\` files — CI is authoritative.

## Related

- Surfaces the orphan \"user tab\" symptom that QA session S-09 observed in the test report (see findings index in QA_REPORT.md). The plugin-side race fix here is the upstream cause of that symptom for the remove path; the sidebar-staleness issue at branch-list level is tracked separately in #114.