### PR TITLE
fix(pane): shell-agent pane name falls back to session name

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -986,6 +986,9 @@ cleanup_test_branch
 contains "inside zellij: prints tab message"        "Opening tab"       "$out"
 contains "inside zellij: calls action new-tab"      "action new-tab"    "$out"
 excludes "inside zellij: layout has no tab wrapper" 'tab name='         "$out"
+# Bare-shell agent: pane should be named after the tab/session, not literal "shell"
+contains "inside zellij: shell agent pane uses session name" 'pane name="some-branch"' "$out"
+excludes "inside zellij: shell agent pane is not 'shell'"    'pane name="shell"'       "$out"
 
 # Outside Zellij, no existing repo session: create session named after repo
 register_managed_cleanup "$HOME" some-branch

--- a/test.sh
+++ b/test.sh
@@ -990,6 +990,34 @@ excludes "inside zellij: layout has no tab wrapper" 'tab name='         "$out"
 contains "inside zellij: shell agent pane uses session name" 'pane name="some-branch"' "$out"
 excludes "inside zellij: shell agent pane is not 'shell'"    'pane name="shell"'       "$out"
 
+# Regression: a non-shell agent command must still drive the pane name
+# (the `*) echo "$base" ;;` arm in pane_name_for_agent_cmd). With agent_cmd
+# `claude`, the pane should be named "claude", not "some-branch" or "shell".
+register_managed_cleanup "$HOME" some-branch
+out_claude=$(ZELLIJ=1 ZELLIJ_SESSION_NAME=fake PATH="$MOCK_BIN:$PATH" "$SCRIPT" spawn some-branch claude 2>&1)
+cleanup_test_branch
+contains "inside zellij: claude agent pane uses 'claude'"          'pane name="claude"'       "$out_claude"
+excludes "inside zellij: claude agent pane is not the session"     'pane name="some-branch"'  "$out_claude"
+excludes "inside zellij: claude agent pane is not 'shell'"         'pane name="shell"'        "$out_claude"
+
+# pane_name_for_agent_cmd unit tests: source the function from zelligent.sh
+# and exercise the empty-agent-cmd branches directly. Codex review flagged
+# that the end-to-end tests can't reach the `[ -z "$agent_cmd" ]` arm,
+# since `spawn` defaults agent_cmd to `$SHELL`.
+PANE_NAME_FN=$(
+  awk '/^pane_name_for_agent_cmd\(\) \{/,/^\}$/' "$SCRIPT"
+)
+result=$(bash -c "$PANE_NAME_FN; pane_name_for_agent_cmd '' ''" 2>&1)
+check "pane_name fn: empty agent+empty session falls back to 'shell'" "shell" "$result"
+result=$(bash -c "$PANE_NAME_FN; pane_name_for_agent_cmd '' 'my-branch'" 2>&1)
+check "pane_name fn: empty agent+session falls back to session name"  "my-branch" "$result"
+result=$(bash -c "$PANE_NAME_FN; pane_name_for_agent_cmd 'bash' ''" 2>&1)
+check "pane_name fn: bash agent+empty session falls back to 'shell'"  "shell" "$result"
+result=$(bash -c "$PANE_NAME_FN; pane_name_for_agent_cmd 'bash' 'my-branch'" 2>&1)
+check "pane_name fn: bash agent+session falls back to session name"   "my-branch" "$result"
+result=$(bash -c "$PANE_NAME_FN; pane_name_for_agent_cmd 'claude --foo' 'my-branch'" 2>&1)
+check "pane_name fn: non-shell agent always wins over session name"   "claude" "$result"
+
 # Outside Zellij, no existing repo session: create session named after repo
 register_managed_cleanup "$HOME" some-branch
 out=$(ZELLIJ="" ZELLIJ_SESSION_NAME="" PATH="$MOCK_BIN:$PATH" "$SCRIPT" spawn some-branch 2>&1)

--- a/zelligent.sh
+++ b/zelligent.sh
@@ -238,13 +238,24 @@ EOF
 
 pane_name_for_agent_cmd() {
   # Derive a short, stable pane title from the user's agent command.
-  # Defaults to "shell" for empty input or bare-shell invocations so the
-  # Zellij pane title doesn't fall back to the raw `bash -lc …` incantation.
+  # For shell-like invocations there's no useful command name to surface, so
+  # fall back to the tab/session name when one is provided (keeps the pane
+  # frame consistent with the sidebar and tab title) — or to literal "shell"
+  # as a last resort.
   local agent_cmd="$1"
+  local session_name="${2:-}"
   local first_word base
 
+  shell_fallback() {
+    if [ -n "$session_name" ]; then
+      echo "$session_name"
+    else
+      echo "shell"
+    fi
+  }
+
   if [ -z "$agent_cmd" ]; then
-    echo "shell"
+    shell_fallback
     return
   fi
 
@@ -254,7 +265,7 @@ pane_name_for_agent_cmd() {
 
   case "$base" in
     "" | sh | bash | zsh | fish | dash | ksh | tcsh)
-      echo "shell"
+      shell_fallback
       ;;
     *)
       echo "$base"
@@ -798,7 +809,7 @@ if [ -z "$1" ]; then
     STARTUP_AGENT_CMD="$SHELL"
     STARTUP_AGENT_RENDER=$(build_agent_command_value "$STARTUP_AGENT_CMD" "$REPO_NAME" "$REPO_ROOT" "$REPO_ROOT" "" "false")
     STARTUP_SIDEBAR=$(sidebar_plugin_content "$PLUGIN_PATH_STARTUP" "$STARTUP_AGENT_CMD" "$REPO_ROOT")
-    STARTUP_PANE_NAME=$(pane_name_for_agent_cmd "$STARTUP_AGENT_CMD")
+    STARTUP_PANE_NAME=$(pane_name_for_agent_cmd "$STARTUP_AGENT_CMD" "$REPO_NAME")
     # Startup tab body: bare shell+lazygit go directly into `tab { … }`
     # without an outer Vertical wrapper, so use the wrapped body form.
     STARTUP_CHILDREN=$(default_tab_body_content "$REPO_ROOT" "$STARTUP_AGENT_RENDER" "$STARTUP_PANE_NAME")
@@ -1031,7 +1042,7 @@ SETUP_SCRIPT="$REPO_ROOT/.zelligent/setup.sh"
 AGENT_CMD_RENDER=$(build_agent_command_value "$AGENT_CMD" "$SESSION_NAME" "$REPO_ROOT" "$WORKTREE_PATH" "$SETUP_SCRIPT" "$NEW_WORKTREE")
 SESSION_AGENT_RENDER=$(build_agent_command_value "$AGENT_CMD" "$REPO_NAME" "$REPO_ROOT" "$REPO_ROOT" "" "false")
 SIDEBAR_RENDER=$(sidebar_plugin_content "$PLUGIN_PATH_LAYOUT" "$AGENT_CMD" "$REPO_ROOT")
-TAB_PANE_NAME=$(pane_name_for_agent_cmd "$AGENT_CMD")
+TAB_PANE_NAME=$(pane_name_for_agent_cmd "$AGENT_CMD" "$SESSION_NAME")
 TAB_CHILDREN_RENDER=$(default_tab_children_content "$WORKTREE_PATH" "$AGENT_CMD_RENDER" "$TAB_PANE_NAME")
 render_layout_fragment "$LAYOUT_SOURCE" "$RENDERED_TAB_FRAGMENT" "$WORKTREE_PATH" "$AGENT_CMD_RENDER" "$SIDEBAR_RENDER" "$TAB_CHILDREN_RENDER"
 render_layout_fragment "$LAYOUT_SOURCE" "$RENDERED_SESSION_TEMPLATE" "$REPO_ROOT" "$SESSION_AGENT_RENDER" "$SIDEBAR_RENDER" "children"


### PR DESCRIPTION
## Summary

Bare-shell agents (just `\$SHELL`, no `claude` or other command) were rendered with the pane title literally set to `"shell"` inside Zellij. Every shell tab looked the same in its pane frame, and the title didn't match the tab name or the sidebar row — which already reflect the branch name.

`pane_name_for_agent_cmd` now takes an optional session/tab name as its second argument and uses it whenever the agent command is empty or resolves to a known shell binary (`sh, bash, zsh, fish, dash, ksh, tcsh`). The literal `"shell"` remains as a last-resort fallback for callers that don't supply a session name.

## Before / After

Before — every shell tab's pane was titled `shell`:

```kdl
pane name="shell" cwd="…/feature-a" command="…/bash" { … }
```

After — pane title matches the tab/session name:

```kdl
pane name="feature-a" cwd="…/feature-a" command="…/bash" { … }
```

## Changes

- **`zelligent.sh`** — `pane_name_for_agent_cmd` accepts an optional second arg; new inline `shell_fallback` helper picks session name when available; both spawn-side call sites (startup tab and `zelligent spawn`) now pass their session name through.
- **`test.sh`** — the existing `inside zellij` spawn block now asserts the rendered KDL contains `pane name="some-branch"` and does NOT contain `pane name="shell"`.

## Test plan

- [x] `bash test.sh` baseline passes locally (exit 0) on these changes. Note: my local environment has a concurrent test-runner that occasionally SIGKILLs in-flight runs and stomps on `.zelligent/` files — CI is authoritative.
- [x] Existing tests for non-shell agent commands (e.g. `claude …`) continue to pass since the `case` arm for non-shell binaries is unchanged.