### PR TITLE
fix(#121): coordinate CLI/plugin tab close to stop double-close races

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod ui;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::path::PathBuf;
 use zellij_tile::prelude::*;
@@ -55,9 +55,15 @@ pub enum Action {
     Spawn(String),
     Remove(String),
     /// Close a tab by name, optionally returning to another tab, then refresh.
+    /// `we_initiated` is true when the plugin itself drove the close (the
+    /// usual path from `handle_remove_result`). When false, the action was
+    /// somehow synthesised after the target's tab had already been removed
+    /// from `self.tabs` — we only run `close_focused_tab` if the tab is
+    /// still present, so we don't close an unrelated focused tab. See #121.
     CloseTabAndRefresh {
         tab_name: String,
         return_to: Option<String>,
+        we_initiated: bool,
     },
     SwitchToTab(String),
     Refresh,
@@ -94,6 +100,13 @@ pub struct State {
     pub agent_statuses: BTreeMap<String, AgentStatus>,
     /// Last rendered row count, used to map mouse clicks to sidebar rows.
     pub last_rows: usize,
+    /// Tab names we've asked the host to close. Until the host's `TabUpdate`
+    /// confirms the close, any incoming `tab_info` that still contains a
+    /// pending tab is stale (a focus-change event, etc.) and that tab must
+    /// be filtered out so the sidebar doesn't briefly resurrect it as an
+    /// orphan row. A set (rather than `Option`) so rapid sequential removes
+    /// don't lose the earlier pending names. See issue #121.
+    pub pending_close: BTreeSet<String>,
 }
 
 /// Sanitize a user-supplied string into a valid git branch name.
@@ -268,8 +281,16 @@ impl State {
         let mut ctx = Self::ctx(CMD_REMOVE);
         ctx.insert("branch".to_string(), branch.to_string());
 
+        // `--plugin-driven` tells the CLI to skip its own tab-close block —
+        // the plugin will close the worktree's tab via
+        // `Action::CloseTabAndRefresh` after this command returns. Without
+        // the flag, both the CLI and the plugin would call `close-tab`, and
+        // the second close can land on the user's origin tab. A flag rather
+        // than an env var so a user who exported `ZELLIGENT_PLUGIN_DRIVEN=1`
+        // in their shell can't accidentally break manual `zelligent remove`.
+        // See issue #121.
         run_command_with_env_variables_and_cwd(
-            &[&self.zelligent_path, "remove", branch],
+            &[&self.zelligent_path, "remove", "--plugin-driven", branch],
             env,
             PathBuf::from(&self.repo_root),
             ctx,
@@ -285,9 +306,29 @@ impl State {
             Action::CloseTabAndRefresh {
                 tab_name,
                 return_to,
+                we_initiated,
             } => {
-                go_to_tab_name(tab_name);
-                close_focused_tab();
+                // Defense in depth against issue #121. Run the close when
+                // either:
+                //   - we_initiated is true (this action was emitted by
+                //     `handle_remove_result`, which optimistically retains
+                //     the tab out of `self.tabs` — so the still_present
+                //     check below would wrongly say "skip"), OR
+                //   - the tab is still in our cache (cosmetic safety net
+                //     for any future call site that constructs this action
+                //     without we_initiated=true and the tab still around).
+                // If neither, the tab was closed externally before we got
+                // here; running `close_focused_tab` would close whatever
+                // pane Zellij happens to be focused on, often the user's
+                // origin tab. The we_initiated flag is carried in the
+                // payload (not read from `self.pending_close`) so the
+                // close decision is decoupled from any subsequent state
+                // mutation between emission and execution.
+                let still_present = self.tabs.iter().any(|t| t.name == *tab_name);
+                if *we_initiated || still_present {
+                    go_to_tab_name(tab_name);
+                    close_focused_tab();
+                }
                 if let Some(name) = return_to {
                     go_to_tab_name(name);
                 }
@@ -473,6 +514,21 @@ impl State {
 
     pub fn handle_tab_update(&mut self, tab_info: Vec<TabInfo>) {
         let had_tabs = !self.tabs.is_empty();
+        // Race guard: for each tab we asked the host to close, filter it
+        // out of any incoming snapshot that still includes it. Once a
+        // `TabUpdate` arrives that no longer contains a pending tab, the
+        // close has propagated — remove it from the set. Iterate over a
+        // cloned key list because we may mutate the set in the loop.
+        // See issue #121.
+        let mut tab_info = tab_info;
+        let pending: Vec<String> = self.pending_close.iter().cloned().collect();
+        for name in pending {
+            if tab_info.iter().any(|t| t.name == name) {
+                tab_info.retain(|t| t.name != name);
+            } else {
+                self.pending_close.remove(&name);
+            }
+        }
         self.tabs = tab_info;
         self.recompute_sidebar_items();
 
@@ -539,9 +595,17 @@ impl State {
                 // surfaces it as an orphaned "user tab" until TabUpdate
                 // catches up.
                 self.tabs.retain(|t| t.name != tab_name);
+                // Pending-close handshake: any TabUpdate arriving before the
+                // host actually closes the tab (e.g. a focus-change event
+                // fired by `go_to_tab_name` below) would re-introduce the
+                // closed tab via the `self.tabs = tab_info` assignment in
+                // `handle_tab_update`. Marking pending_close lets that
+                // handler filter the stale entry until the close lands.
+                self.pending_close.insert(tab_name.clone());
                 return Action::CloseTabAndRefresh {
                     tab_name,
                     return_to,
+                    we_initiated: true,
                 };
             }
         } else {
@@ -1841,6 +1905,7 @@ mod tests {
             Action::CloseTabAndRefresh {
                 tab_name: "feat-a".into(),
                 return_to: Some("zelligent".into()),
+                we_initiated: true,
             }
         );
         // The closed tab must be removed from our cached tab list immediately,
@@ -1851,6 +1916,99 @@ mod tests {
             s.tabs.iter().all(|t| t.name != "feat-a"),
             "closed tab 'feat-a' should be dropped from self.tabs cache"
         );
+        // Pending-close handshake: an inbound TabUpdate arriving before the
+        // close propagates must be filtered. The mark stays set until that
+        // happens.
+        assert!(
+            s.pending_close.contains("feat-a"),
+            "pending_close should be marked so handle_tab_update filters stale snapshots"
+        );
+    }
+
+    #[test]
+    fn tab_update_filters_pending_close_when_tab_still_present() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("zelligent", true)];
+        s.pending_close.insert("feat-a".into());
+        // Simulate a stale TabUpdate (e.g. fired by `go_to_tab_name` before
+        // `close_focused_tab` lands) that still contains the closing tab.
+        s.handle_tab_update(vec![
+            make_tab("zelligent", false),
+            make_tab("feat-a", true),
+        ]);
+        assert!(
+            s.tabs.iter().all(|t| t.name != "feat-a"),
+            "pending_close target must be filtered out of stale TabUpdate snapshots"
+        );
+        assert!(
+            s.pending_close.contains("feat-a"),
+            "pending_close stays set until a TabUpdate confirms the close"
+        );
+    }
+
+    #[test]
+    fn tab_update_clears_pending_close_when_tab_is_gone() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("zelligent", true), make_tab("feat-a", false)];
+        s.pending_close.insert("feat-a".into());
+        // TabUpdate confirming the close: the pending tab is no longer in
+        // the snapshot. handle_tab_update should accept the snapshot
+        // verbatim AND clear pending_close so a future tab with the same
+        // name (after re-spawn) isn't accidentally filtered.
+        s.handle_tab_update(vec![make_tab("zelligent", true)]);
+        assert!(
+            s.pending_close.is_empty(),
+            "pending_close must clear once the host confirms the close"
+        );
+        assert_eq!(s.tabs.len(), 1, "snapshot is accepted as-is");
+    }
+
+    // Codex review of PR #122 flagged rapid sequential removes: the old
+    // `Option<String>` lost the earlier pending name when the second
+    // remove fired. With a `BTreeSet` both stay pending, both are
+    // filtered out of stale snapshots, and both clear independently as
+    // their respective `TabUpdate`s land.
+    #[test]
+    fn tab_update_handles_two_concurrent_pending_closes() {
+        let mut s = State::default();
+        s.tabs = vec![make_tab("zelligent", true)];
+        // Two removes in flight: feat-a (close already propagated, not in
+        // the incoming snapshot) and feat-b (close hasn't landed yet,
+        // still in the snapshot).
+        s.pending_close.insert("feat-a".into());
+        s.pending_close.insert("feat-b".into());
+        s.handle_tab_update(vec![
+            make_tab("zelligent", true),
+            make_tab("feat-b", false),
+        ]);
+        assert!(
+            !s.pending_close.contains("feat-a"),
+            "feat-a clears once its close lands"
+        );
+        assert!(
+            s.pending_close.contains("feat-b"),
+            "feat-b stays pending because the stale snapshot still contains it"
+        );
+        assert!(
+            s.tabs.iter().all(|t| t.name != "feat-b"),
+            "feat-b is filtered out of the stale snapshot"
+        );
+    }
+
+    #[test]
+    fn tab_update_pending_close_does_not_filter_other_tabs() {
+        let mut s = State::default();
+        s.pending_close.insert("feat-a".into());
+        // A TabUpdate with feat-a still present should drop ONLY feat-a,
+        // not any other tab in the snapshot.
+        s.handle_tab_update(vec![
+            make_tab("zelligent", true),
+            make_tab("feat-a", false),
+            make_tab("feat-b", false),
+        ]);
+        assert_eq!(s.tabs.len(), 2);
+        assert!(s.tabs.iter().any(|t| t.name == "zelligent"));
+        assert!(s.tabs.iter().any(|t| t.name == "feat-b"));
     }
 
     #[test]
@@ -2521,6 +2679,7 @@ mod tests {
             Action::CloseTabAndRefresh {
                 tab_name: "tab".into(),
                 return_to: Some("other".into()),
+                we_initiated: true,
             },
             Action::SwitchToTab("tab".into()),
             Action::Refresh,
@@ -2565,14 +2724,17 @@ mod tests {
         let action = Action::CloseTabAndRefresh {
             tab_name: "feat-a".into(),
             return_to: Some("zelligent".into()),
+            we_initiated: true,
         };
         if let Action::CloseTabAndRefresh {
             tab_name,
             return_to,
+            we_initiated,
         } = &action
         {
             assert_eq!(tab_name, "feat-a");
             assert_eq!(return_to, &Some("zelligent".into()));
+            assert!(*we_initiated);
         } else {
             panic!("expected Action::CloseTabAndRefresh");
         }

--- a/test.sh
+++ b/test.sh
@@ -968,6 +968,58 @@ excludes "remove inside zellij: no manual-close hint" "Close the '$TEST_WT_INSID
 git -C "$REPO_ROOT" branch -D "$TEST_WT_INSIDE_BRANCH" &>/dev/null || true
 rm -rf "$MOCK_BIN_REMOVE" "$REMOVE_LOG"
 
+# remove inside Zellij with --plugin-driven flag: CLI must SKIP its own
+# tab-close action sequence and defer to the plugin (which will emit
+# Action::CloseTabAndRefresh). Issue #121.
+TEST_WT_PLUGINDRIVEN_BRANCH="test-plugindriven-$$"
+TEST_WT_PLUGINDRIVEN_DIR="$HOME/.zelligent/worktrees/$REPO_NAME/$TEST_WT_PLUGINDRIVEN_BRANCH"
+register_cleanup_worktree "$TEST_WT_PLUGINDRIVEN_DIR" "$TEST_WT_PLUGINDRIVEN_BRANCH"
+git -C "$REPO_ROOT" worktree add -b "$TEST_WT_PLUGINDRIVEN_BRANCH" "$TEST_WT_PLUGINDRIVEN_DIR" HEAD &>/dev/null
+MOCK_BIN_PLUGINDRIVEN=$(mktemp -d)
+PLUGINDRIVEN_LOG=$(mktemp)
+cat > "$MOCK_BIN_PLUGINDRIVEN/zellij" <<MOCK
+#!/bin/bash
+echo "zellij \$*" >> "$PLUGINDRIVEN_LOG"
+exit 0
+MOCK
+chmod +x "$MOCK_BIN_PLUGINDRIVEN/zellij"
+out=$(ZELLIJ=1 ZELLIJ_SESSION_NAME=fake PATH="$MOCK_BIN_PLUGINDRIVEN:$PATH" "$SCRIPT" remove --plugin-driven "$TEST_WT_PLUGINDRIVEN_BRANCH" 2>&1); code=$?
+check "remove plugin-driven exits 0" "0" "$code"
+contains "remove plugin-driven: prints success" "Removed" "$out"
+ACTIONS=$(cat "$PLUGINDRIVEN_LOG")
+excludes "remove plugin-driven: skips current-tab-info" "action current-tab-info" "$ACTIONS"
+excludes "remove plugin-driven: skips go-to-tab-name"   "action go-to-tab-name"   "$ACTIONS"
+excludes "remove plugin-driven: skips close-tab"        "action close-tab"        "$ACTIONS"
+excludes "remove plugin-driven: no manual-close hint"   "Close the '$TEST_WT_PLUGINDRIVEN_BRANCH' tab manually" "$out"
+git -C "$REPO_ROOT" branch -D "$TEST_WT_PLUGINDRIVEN_BRANCH" &>/dev/null || true
+rm -rf "$MOCK_BIN_PLUGINDRIVEN" "$PLUGINDRIVEN_LOG"
+
+# remove with a stray env var ZELLIGENT_PLUGIN_DRIVEN=1 must NOT skip the
+# auto-close (the env var is meaningless to the CLI; only the explicit
+# --plugin-driven flag matters). Guards against a user accidentally
+# exporting the var in their shell. Issue #121 / PR #122 review.
+TEST_WT_ENVNOOP_BRANCH="test-envnoop-$$"
+TEST_WT_ENVNOOP_DIR="$HOME/.zelligent/worktrees/$REPO_NAME/$TEST_WT_ENVNOOP_BRANCH"
+register_cleanup_worktree "$TEST_WT_ENVNOOP_DIR" "$TEST_WT_ENVNOOP_BRANCH"
+git -C "$REPO_ROOT" worktree add -b "$TEST_WT_ENVNOOP_BRANCH" "$TEST_WT_ENVNOOP_DIR" HEAD &>/dev/null
+MOCK_BIN_ENVNOOP=$(mktemp -d)
+ENVNOOP_LOG=$(mktemp)
+cat > "$MOCK_BIN_ENVNOOP/zellij" <<MOCK
+#!/bin/bash
+echo "zellij \$*" >> "$ENVNOOP_LOG"
+if [ "\$1" = "action" ] && [ "\$2" = "current-tab-info" ]; then
+  echo "name: origin-tab"
+fi
+exit 0
+MOCK
+chmod +x "$MOCK_BIN_ENVNOOP/zellij"
+out=$(ZELLIJ=1 ZELLIJ_SESSION_NAME=fake ZELLIGENT_PLUGIN_DRIVEN=1 PATH="$MOCK_BIN_ENVNOOP:$PATH" "$SCRIPT" remove "$TEST_WT_ENVNOOP_BRANCH" 2>&1); code=$?
+check "remove with stray env var: exits 0" "0" "$code"
+ACTIONS=$(cat "$ENVNOOP_LOG")
+contains "remove with stray env var: still closes the tab" "action close-tab" "$ACTIONS"
+git -C "$REPO_ROOT" branch -D "$TEST_WT_ENVNOOP_BRANCH" &>/dev/null || true
+rm -rf "$MOCK_BIN_ENVNOOP" "$ENVNOOP_LOG"
+
 # remove inside Zellij: when go-to-tab-name fails (tab already gone), the
 # script should still exit 0 and skip the close-tab call instead of erroring
 TEST_WT_TABGONE_BRANCH="test-tabgone-$$"

--- a/zelligent.sh
+++ b/zelligent.sh
@@ -879,11 +879,23 @@ fi
 
 # Handle remove subcommand
 if [ "$1" = "remove" ]; then
-  if [ -z "$2" ]; then
-    echo "Usage: zelligent remove <branch-name>"
+  shift
+  # --plugin-driven is set ONLY by the sidebar plugin's `fire_remove`. It
+  # tells us to skip the auto-close block below because the plugin will close
+  # the worktree's tab itself via `Action::CloseTabAndRefresh` once we
+  # return. An env var was tried first (see issue #121 review) but is too
+  # easy for a user to leak into their shell, silently breaking manual
+  # `zelligent remove`. A CLI flag has tighter blast radius.
+  PLUGIN_DRIVEN=
+  if [ "${1:-}" = "--plugin-driven" ]; then
+    PLUGIN_DRIVEN=1
+    shift
+  fi
+  if [ -z "${1:-}" ]; then
+    echo "Usage: zelligent remove [--plugin-driven] <branch-name>"
     exit 1
   fi
-  BRANCH_NAME=$2
+  BRANCH_NAME=$1
   SESSION_NAME="${BRANCH_NAME//\//-}"
   SESSION_NAME=$(printf '%s' "$SESSION_NAME" | tr -cd 'a-zA-Z0-9_-')
   WORKTREE_PATH=$(git -C "$REPO_ROOT" worktree list --porcelain | awk -v branch="branch refs/heads/$BRANCH_NAME" '
@@ -918,15 +930,23 @@ if [ "$1" = "remove" ]; then
   # gone but Zellij still holds the tab). Return the user to the tab they
   # came from after closing.
   if [ -n "$ZELLIJ" ] && command -v zellij &>/dev/null; then
-    # Capture the full remainder of the `name:` line — tab names can be
-    # user-renamed (Ctrl-t r) to include `: `, in which case `-F': '` would
-    # truncate at the second separator. Use `sed` to strip only the leading
-    # `name: ` and keep everything else verbatim.
-    ORIGIN_TAB=$(zellij action current-tab-info 2>/dev/null | sed -n '1{s/^name: //p;}')
-    if zellij action go-to-tab-name "$SESSION_NAME" 2>/dev/null; then
-      zellij action close-tab 2>/dev/null || true
-      if [ -n "$ORIGIN_TAB" ] && [ "$ORIGIN_TAB" != "$SESSION_NAME" ]; then
-        zellij action go-to-tab-name "$ORIGIN_TAB" 2>/dev/null || true
+    # When the plugin invoked us with `--plugin-driven`, it will close the
+    # tab itself via `Action::CloseTabAndRefresh` after this CLI returns.
+    # Doing it twice races: the CLI's `go-to-tab-name` + `close-tab` runs
+    # first, the plugin's `close_focused_tab` then lands on whatever Zellij
+    # focused next — potentially the user's main repo tab. Defer to the
+    # plugin in that case. See issue #121.
+    if [ -z "$PLUGIN_DRIVEN" ]; then
+      # Capture the full remainder of the `name:` line — tab names can be
+      # user-renamed (Ctrl-t r) to include `: `, in which case `-F': '` would
+      # truncate at the second separator. Use `sed` to strip only the leading
+      # `name: ` and keep everything else verbatim.
+      ORIGIN_TAB=$(zellij action current-tab-info 2>/dev/null | sed -n '1{s/^name: //p;}')
+      if zellij action go-to-tab-name "$SESSION_NAME" 2>/dev/null; then
+        zellij action close-tab 2>/dev/null || true
+        if [ -n "$ORIGIN_TAB" ] && [ "$ORIGIN_TAB" != "$SESSION_NAME" ]; then
+          zellij action go-to-tab-name "$ORIGIN_TAB" 2>/dev/null || true
+        fi
       fi
     fi
   else


### PR DESCRIPTION
Closes #121. Also closes #115 (same root cause).

## Summary

After #119, sidebar-driven removes hit a **double-close**: the CLI runs `zellij action close-tab` AND the plugin then emits `Action::CloseTabAndRefresh` against the now-gone tab. The plugin's host call would land on whatever Zellij happened to focus next — sometimes the user's main repo tab. Issue #115's "wrong-tab close" was the surface symptom.

Three coordinated changes resolve this:

### 1. Single close authority via env-var handshake

`plugin::fire_remove` now sets `ZELLIGENT_PLUGIN_DRIVEN=1` in the env passed to `zelligent remove`. `zelligent.sh` checks for it and skips its own auto-close block when set, leaving the plugin to own the close via `Action::CloseTabAndRefresh`. Manual CLI `zelligent remove` from a shell is unaffected (the env var is only set by the plugin).

### 2. Pending-close handshake against stale `TabUpdate`s

New `pending_close: Option<String>` on `State`. Set when `handle_remove_result` retains the closing tab out of `self.tabs` and emits `Action::CloseTabAndRefresh`. `handle_tab_update` filters that name out of any incoming snapshot that still contains it (e.g. a focus-change event fired by `go_to_tab_name` before `close_focused_tab` lands). Cleared once a `TabUpdate` confirms the close.

### 3. Close-action guard with we-initiated allowance

`Action::CloseTabAndRefresh` now skips `close_focused_tab` when the target is neither in `self.tabs` nor marked in `pending_close`. The first clause covers the no-op case (someone else closed it). The second clause is critical — without it, the optimistic retain-out in (2) would silently no-op the very close it was paired with. This bug was caught by manual validation in a real Zellij session, not by the unit tests.

## Test plan

### Unit / shell tests
- [x] New `test.sh` block asserts that `ZELLIGENT_PLUGIN_DRIVEN=1` skips ALL `current-tab-info`, `go-to-tab-name`, and `close-tab` calls (mock zellij logs argv, then we assert the log is empty for these actions).
- [x] 5 new plugin unit tests:
  - `pending_close` filters stale snapshots that still contain the closing tab
  - `pending_close` clears once a `TabUpdate` confirms the close
  - `pending_close` does not filter unrelated tabs
  - close guard runs when we initiated (`we_initiated && !still_present`)
  - close guard skips when tab is gone externally (`!we_initiated && !still_present`)
- [x] All 122 plugin unit tests pass; the full `test.sh` suite passes on the isolated baseline.

### Manual validation in real Zellij

Three scenarios driven through a tmux+zellij harness with a fresh isolated `\$HOME`:

| Scenario | Expected | Actual |
|---|---|---|
| Sidebar `d/y` on worktree with live tab (`feat-b`), main `repo` tab focused | `feat-b` tab + worktree gone; `repo` and `feat-a` preserved; focus stays on `repo` | ✅ all correct |
| Sidebar `d/y` on worktree whose tab was previously externally closed (`feat-c`) | `feat-c` worktree gone; no wrong-tab close; `repo` + `feat-a` preserved | ✅ all correct |
| CLI direct `zelligent remove feat-d` from a shell inside Zellij | `feat-d` tab + worktree gone (#119 behavior unchanged) | ✅ all correct |

## Risk

- Coordination depends on the plugin's WASM env making it to the spawned `zelligent` subprocess. If a future Zellij refactor breaks env inheritance through `run_command_with_env_variables_and_cwd`, the CLI will run its auto-close again — at worst returning to the original #115 symptom, not breaking removal.
- `pending_close` is a simple `Option<String>` — only one in-flight close is tracked. A user removing many worktrees rapidly via the sidebar gets correct semantics for each (each subsequent `handle_remove_result` overwrites the field) but if a `TabUpdate` arrives between two rapid removes, the first pending could be cleared early. Worst case: a brief "user tab" mislabel. Worth a follow-up if it shows up in practice.