### PR TITLE
fix(plugin): refresh worktrees on TabUpdate when a tab is unmatched

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -529,6 +529,13 @@ impl State {
                 self.pending_close.remove(&name);
             }
         }
+
+        // Snapshot the previous tab names before we overwrite. Used below to
+        // detect which tabs in the new snapshot are *newly appeared* — only
+        // those should drive a worktree refresh.
+        let previously_known: BTreeSet<String> =
+            self.tabs.iter().map(|t| t.name.clone()).collect();
+
         self.tabs = tab_info;
         self.recompute_sidebar_items();
 
@@ -538,20 +545,29 @@ impl State {
             self.select_active_sidebar_item();
         }
 
-        // Refresh worktrees if any tab in the new snapshot is unmatched. This
-        // self-heals the "user tab" mislabel that appears when our cached
-        // `self.worktrees` is stale relative to the actual tabs — happens when
-        // a worktree is created out-of-band (e.g. agent runs `zelligent spawn`
-        // via bash) or when our last refresh raced with a spawn and missed the
-        // new entry.
-        let has_unmatched = self.tabs.iter().any(|t| {
-            t.name != self.repo_name
-                && !self
-                    .worktrees
-                    .iter()
-                    .any(|wt| Self::tab_name_for_branch(&wt.branch) == t.name)
+        // Refresh worktrees only when a *newly-appeared* tab has no matching
+        // worktree. This self-heals the "user tab" mislabel that appears when
+        // our cached `self.worktrees` is stale relative to the actual tabs —
+        // happens when a worktree is created out-of-band (e.g. agent runs
+        // `zelligent spawn` via bash) or when the last refresh raced with a
+        // spawn and missed the new entry.
+        //
+        // Without the "newly-appeared" check, a legitimate persistent
+        // user-created tab (one with no underlying worktree) would drive a
+        // Refresh on *every* TabUpdate forever — including focus changes.
+        // Restricting to new tabs keeps the refresh one-shot per tab and
+        // closes any theoretical TabUpdate→Refresh feedback path.
+        let worktree_tab_names: BTreeSet<String> = self
+            .worktrees
+            .iter()
+            .map(|wt| Self::tab_name_for_branch(&wt.branch))
+            .collect();
+        let has_new_unmatched = self.tabs.iter().any(|t| {
+            !previously_known.contains(&t.name)
+                && t.name != self.repo_name
+                && !worktree_tab_names.contains(&t.name)
         });
-        if has_unmatched {
+        if has_new_unmatched {
             Action::Refresh
         } else {
             Action::None
@@ -2182,6 +2198,32 @@ mod tests {
             make_tab("feat-a", false),
         ]);
         assert_eq!(action, Action::None);
+    }
+
+    #[test]
+    fn tab_update_with_persistent_unmatched_tab_only_refreshes_once() {
+        // Reviewer concern: a legitimate persistent user-created tab (no
+        // underlying worktree) must NOT drive a Refresh on every subsequent
+        // TabUpdate (focus changes etc.). The "newly-appeared" gate makes
+        // refresh one-shot per such tab.
+        let mut s = State::default();
+        s.handle_list_worktrees(Some(0), b"feat-a\tfeat-a\n", b"");
+
+        // First sighting of the user tab: Refresh fires so we can confirm
+        // there's no worktree we missed.
+        let first = s.handle_tab_update(vec![
+            make_tab("feat-a", false),
+            make_tab("notes", true),
+        ]);
+        assert_eq!(first, Action::Refresh);
+
+        // Worktrees still don't include "notes". The next TabUpdate (focus
+        // moved back to feat-a) must NOT trigger another Refresh.
+        let second = s.handle_tab_update(vec![
+            make_tab("feat-a", true),
+            make_tab("notes", false),
+        ]);
+        assert_eq!(second, Action::None);
     }
 
     #[test]

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -512,7 +512,7 @@ impl State {
         self.branches = parse_branches(&output);
     }
 
-    pub fn handle_tab_update(&mut self, tab_info: Vec<TabInfo>) {
+    pub fn handle_tab_update(&mut self, tab_info: Vec<TabInfo>) -> Action {
         let had_tabs = !self.tabs.is_empty();
         // Race guard: for each tab we asked the host to close, filter it
         // out of any incoming snapshot that still includes it. Once a
@@ -536,6 +536,25 @@ impl State {
         // that may have been established from worktrees before tab state arrived.
         if !had_tabs {
             self.select_active_sidebar_item();
+        }
+
+        // Refresh worktrees if any tab in the new snapshot is unmatched. This
+        // self-heals the "user tab" mislabel that appears when our cached
+        // `self.worktrees` is stale relative to the actual tabs — happens when
+        // a worktree is created out-of-band (e.g. agent runs `zelligent spawn`
+        // via bash) or when our last refresh raced with a spawn and missed the
+        // new entry.
+        let has_unmatched = self.tabs.iter().any(|t| {
+            t.name != self.repo_name
+                && !self
+                    .worktrees
+                    .iter()
+                    .any(|wt| Self::tab_name_for_branch(&wt.branch) == t.name)
+        });
+        if has_unmatched {
+            Action::Refresh
+        } else {
+            Action::None
         }
     }
 
@@ -1102,10 +1121,7 @@ impl ZellijPlugin for State {
                     }
                 }
             }
-            Event::TabUpdate(tab_info) => {
-                self.handle_tab_update(tab_info);
-                Action::None
-            }
+            Event::TabUpdate(tab_info) => self.handle_tab_update(tab_info),
             Event::Key(key) => match self.mode {
                 Mode::Loading => Action::None,
                 Mode::NotGitRepo => self.handle_key_not_git_repo(&key),
@@ -2135,6 +2151,37 @@ mod tests {
 
         assert_eq!(s.selected_index, 1);
         assert_eq!(s.sidebar_items[1].tab_name, "feat-b");
+    }
+
+    #[test]
+    fn tab_update_with_unmatched_worktree_tab_returns_refresh() {
+        // Reproduces the "user tab" mislabel: an external `zelligent spawn`
+        // (e.g. an agent running it via bash) creates a tab that lands in the
+        // host's TabUpdate before our worktree-list cache is refreshed. The
+        // tab should drive a Refresh so the sidebar self-heals.
+        let mut s = State::default();
+        s.handle_list_worktrees(Some(0), b"feat-a\tfeat-a\n", b"");
+        let action = s.handle_tab_update(vec![
+            make_tab("feat-a", false),
+            make_tab("feat-b", true), // not in worktrees yet
+        ]);
+        assert_eq!(action, Action::Refresh);
+    }
+
+    #[test]
+    fn tab_update_with_all_tabs_matched_returns_none() {
+        // No spurious refresh when every tab is already explained by either
+        // the repo tab or a known worktree.
+        let mut s = State {
+            repo_name: "zelligent".into(),
+            ..Default::default()
+        };
+        s.handle_list_worktrees(Some(0), b"feat-a\tfeat-a\n", b"");
+        let action = s.handle_tab_update(vec![
+            make_tab("zelligent", true),
+            make_tab("feat-a", false),
+        ]);
+        assert_eq!(action, Action::None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Sidebar mislabeled a worktree tab as `user tab` when the worktree was created by an out-of-band `zelligent spawn` (e.g. an agent invoking the CLI via bash). The host's `TabUpdate` landed before our cached `self.worktrees` was refreshed, so `recompute_sidebar_items` couldn't match the new tab to any worktree and the state never self-healed.
- `handle_tab_update` now returns `Action::Refresh` when any tab is unmatched, triggering `zelligent list-worktrees` and a re-render.
- Returning an `Action` (vs. calling `fire_list_worktrees` directly from `handle_tab_update`) keeps the Zellij host-shim out of code paths the test linker reaches — existing `fire_*` call sites all sit inside `execute()`, which tests never reach.

## Repro
1. `zelligent` in a fresh repo session.
2. UI-spawn worktree `agent/foo` (sidebar `i` → name → Enter).
3. UI-spawn worktree `agent/bar`.
4. `Ctrl+t 1` to switch back to the local tab.
5. Before this fix: `agent/bar`'s subtitle became `user tab`; display name fell back from `agent/bar` to `agent-bar`.

## Test plan
- [x] `cargo test --target aarch64-apple-darwin` — 27 lib tests + 7 tab_update tests pass
- [x] Two new tests added: `tab_update_with_unmatched_worktree_tab_returns_refresh`, `tab_update_with_all_tabs_matched_returns_none`
- [x] Manually reproduced original bug and verified fix via tmux-driven zellij session

🤖 Generated with [Claude Code](https://claude.com/claude-code)