### PR TITLE
docs: add RECORDING_DEMOS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ A `.claude/hooks/pre-push-block.sh` hook blocks `git push` unless prefixed with 
 | Product & UX conventions | [docs/PRODUCT_SENSE.md](docs/PRODUCT_SENSE.md) |
 | Code conventions & Zellij gotchas | [docs/CONVENTIONS.md](docs/CONVENTIONS.md) |
 | Quality scoring | [docs/QUALITY_SCORE.md](docs/QUALITY_SCORE.md) |
+| Recording demo videos | [docs/RECORDING_DEMOS.md](docs/RECORDING_DEMOS.md) |
 | Worktree spawn/remove lifecycle | [docs/design-docs/worktree-lifecycle.md](docs/design-docs/worktree-lifecycle.md) |
 | Tab creation & index vs position bug | [docs/design-docs/tab-management.md](docs/design-docs/tab-management.md) |
 | Agent status notifications | [docs/design-docs/agent-notifications.md](docs/design-docs/agent-notifications.md) |

--- a/docs/RECORDING_DEMOS.md
+++ b/docs/RECORDING_DEMOS.md
@@ -1,125 +1,193 @@
 # Recording demo videos
 
-How the `demo.mp4` / `demo.gif` shipped at the repo root were produced, with the
-exact tooling and rough recipes. The script that drives the recording itself
-lives in a local `DEMO_SCRIPT.md` at the repo root (kept per-recording, not
-checked in) — this doc covers the
-post-production side only.
+How the `demo.mp4` / `demo.gif` shipped at the repo root were produced.
+Reconstructed from the session that actually recorded them
+(2026-05-27 / 2026-05-28).
 
-## Tools we actually used
+The recipe is **scripted, not interactive** — there is no mouse, no
+QuickTime, no manual key-pressing. A shell script drives a real Zellij
+session from outside via tmux while `asciinema` captures the inner
+session's terminal output, then `agg` and `ffmpeg` convert the cast to
+GIF and MP4.
 
-- **macOS QuickTime Player** (`⌘⇧5` → "Record Selected Portion") — primary
-  screen recording with mic audio. Produces the 1734×1080 30fps H.264 + AAC
-  `demo.mp4`. Pick the Zellij window region; uncheck "Show Floating Thumbnail";
-  set the mic input. Output lands on the desktop.
-- **`ffmpeg`** (`brew install ffmpeg`) — every cut, mute, crop, scale, and
-  encode below.
-- **`agg`** (`brew install agg`) — only used if you go down the
-  asciinema route (see "Alternate: asciinema → mp4" below).
-
-You don't need `vhs` / `terminalizer` for the current demos. The 100fps
-`demo-silent.mp4` in the tree was an asciinema export experiment from a
-different run; it isn't the source of the shipped clips.
-
-## Pipeline for the shipped clips
-
-### 1. Record
-
-QuickTime, region capture over the Zellij window. Follow the beats in
-your local `DEMO_SCRIPT.md`. Stop on `⌘⌃Esc`. Save as `demo-raw.mov`.
-
-### 2. Trim + mute (if needed)
+## Tools
 
 ```bash
-# Trim to the on-script range, drop audio (for the silent variant)
-ffmpeg -ss 00:00:02 -to 00:02:18 -i demo-raw.mov \
-  -an -c:v copy demo-silent.mp4
-
-# Keep audio
-ffmpeg -ss 00:00:02 -to 00:02:18 -i demo-raw.mov \
-  -c copy demo.mp4
+brew install asciinema agg tmux ffmpeg
 ```
 
-`-c copy` preserves the original codec (no re-encode). For frame-accurate
-trims drop `-c copy` and let ffmpeg re-encode.
+- `asciinema` (3.2+) — records terminal output to a `.cast` file. No
+  mouse, no chrome, no host font dependency.
+- `agg` (1.8+) — renders an asciicast to a GIF. Theme- and font-aware.
+- `tmux` — used twice, nested. See the architecture note below.
+- `ffmpeg` — final GIF → MP4 step.
 
-### 3. Make the GIF
+## The double-tmux architecture (this is the load-bearing trick)
 
-The shipped `demo.gif` is a 8-second 900×561 10fps clip — a short loop, not
-the whole video. Two-pass palette flow gives much smaller files than a
-naive single-pass:
+`asciinema rec` needs a foreground pty to record. If you launch it
+inline, the very terminal you're driving from is the one being
+captured — you can't send keystrokes from outside. Workaround:
+
+- **`demo-rec`** — inner tmux session, 220×60, status bar off. This is
+  the shell where `zelligent` runs and where Claude agents live. The
+  *contents* of this session are what gets recorded.
+- **`rec-host`** — outer tmux session, same size. It runs
+  `asciinema rec --overwrite -c 'tmux attach -t demo-rec' …`. We never
+  view `rec-host`; it exists so asciinema gets a pty without us holding
+  the foreground.
+
+Drive the demo by sending keys to `demo-rec` from the host shell:
 
 ```bash
-# Pass 1 — extract palette from the chosen window
-ffmpeg -ss 00:00:35 -t 8 -i demo.mp4 \
-  -vf "fps=10,scale=900:-1:flags=lanczos,palettegen=stats_mode=diff" \
-  -y palette.png
-
-# Pass 2 — apply the palette
-ffmpeg -ss 00:00:35 -t 8 -i demo.mp4 -i palette.png \
-  -lavfi "fps=10,scale=900:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" \
-  -y demo.gif
+tmux send-keys -t demo-rec -l "zelligent spawn agent/foo 'claude \"…\"'"
+sleep 1.8
+tmux send-keys -t demo-rec Enter
 ```
 
-Tune knobs:
+Stop the recording by killing `demo-rec`. That makes the attached
+client (inside `rec-host`) exit, which makes `asciinema` flush the cast
+file. Killing `rec-host` directly leaves a half-written cast — go
+through `demo-rec` first.
 
-- `fps=10` — drop to 8 if file size is still too big for GitHub's ~10MB
-  inline-render cap; 15 if motion feels choppy.
-- `scale=900:-1` — match the README column. Bigger = readable text, bigger
-  file. Below 720 the terminal text gets hard to read.
-- `bayer_scale` — 5 is the dithering sweet spot for terminal output; lower
-  values produce more banding, higher values produce file-size bloat.
+## The actual recording script
 
-### 4. Sanity check
+The script that produced the shipped clips lived at
+`/tmp/record-zelligent-demo.sh`. It's not committed; it was per-take.
+Skeleton:
 
 ```bash
-ffprobe -v error -show_entries format=duration,size:stream=width,height,r_frame_rate,codec_name demo.gif
-du -h demo.mp4 demo.gif
+#!/bin/bash
+set -u
+
+CAST=/tmp/zelligent-demo.cast
+GIF=/Users/philipp/code/zelligent/demo.gif
+MP4=/Users/philipp/code/zelligent/demo.mp4
+REPO=/tmp/httpie-demo
+COLS=220
+ROWS=60
+
+# Clean slate
+tmux kill-session -t demo-rec 2>/dev/null
+tmux kill-session -t rec-host 2>/dev/null
+zellij delete-session httpie-demo --force 2>/dev/null
+rm -f "$CAST"
+
+# Inner: the session being recorded
+tmux new -d -s demo-rec -x "$COLS" -y "$ROWS" -c "$REPO"
+tmux set-option -t demo-rec status off
+sleep 0.5
+
+# Outer: asciinema wrapping `tmux attach -t demo-rec`
+tmux new -d -s rec-host -x "$COLS" -y "$ROWS" \
+  "asciinema rec --overwrite -c 'tmux attach -t demo-rec' $CAST"
+tmux set-option -t rec-host status off
+sleep 2
+
+# Helpers
+type_line() {
+  tmux send-keys -t demo-rec -l "$1"
+  sleep "${2:-1.8}"
+  tmux send-keys -t demo-rec Enter
+}
+tab() {                          # zellij tab leader + number
+  tmux send-keys -t demo-rec C-t
+  sleep 0.3
+  tmux send-keys -t demo-rec "$1"
+  sleep "${2:-4}"
+}
+
+# --- Demo beats ----------------------------------------------------------
+
+sleep 3                          # cold open: prompt visible for a beat
+
+type_line "zelligent" 2
+sleep 9                          # layout boots, sidebar + lazygit render
+
+# Spawn agent A — real Claude, --dangerously-skip-permissions so the
+# script doesn't have to handle the trust prompt
+SPAWN_A='zelligent spawn agent/fix-auth-decode '"'"'claude --dangerously-skip-permissions "Fix httpie issue 1623: …"'"'"
+type_line "$SPAWN_A" 3
+sleep 36                         # tab opens, Claude reads + produces output
+
+tab 1 5                          # back to main shell
+type_line "vim httpie/cli/argparser.py +282" 2
+sleep 10                         # let viewer see the TODO + bug site
+tmux send-keys -t demo-rec Escape; sleep 0.3
+tmux send-keys -t demo-rec ":q" Enter
+sleep 3
+
+# Spawn agent B
+SPAWN_B='zelligent spawn agent/refactor-process-auth '"'"'claude --dangerously-skip-permissions "Refactor …"'"'"
+type_line "$SPAWN_B" 3
+sleep 31
+
+tab 1 6                          # parallelism reveal
+tab 2 7
+tab 3 7
+tab 1 6                          # rest on the sidebar
+
+# --- Stop + convert ------------------------------------------------------
+tmux kill-session -t demo-rec
+sleep 2
+tmux kill-session -t rec-host 2>/dev/null
+
+agg --idle-time-limit 1.5 --theme dracula --font-size 14 "$CAST" "$GIF"
+
+ffmpeg -y -i "$GIF" \
+  -movflags faststart -pix_fmt yuv420p \
+  -vf "scale=1920:-2:flags=lanczos" "$MP4"
+
+zellij delete-session httpie-demo --force 2>/dev/null
 ```
 
-GitHub inline-renders GIFs up to ~10MB; the shipped `demo.gif` lands at ~1MB.
-For longer or higher-fidelity demos prefer uploading the MP4 as a GitHub
-attachment instead — drag it into a PR or issue body and GitHub plays it
-inline.
+## Pacing rules that mattered
 
-## Alternate: asciinema → mp4 (the `demo-silent.mp4` route)
+- **Human eyes need 2–3s minimum** to register a state change, longer
+  on busy frames. Most `sleep` values in the script are 2–5s for short
+  actions and 7–36s when Claude is doing real work.
+- `agg --idle-time-limit 1.5` collapses any idle gap longer than 1.5s
+  down to 1.5s. Without this the cast is mostly empty time during
+  Claude's thinking. With this, the final GIF reads as continuous
+  motion.
+- Use `tmux send-keys -l` (literal mode) for the spawn commands.
+  Without `-l`, escape sequences in the prompt string get interpreted
+  as tmux key syntax.
 
-If you'd rather have a deterministic, scriptable terminal recording with no
-window chrome:
+## Pre-record checklist
 
-```bash
-brew install asciinema agg
+1. `cd` to a fresh clone of the target repo (the shipped demo uses
+   `/tmp/httpie-demo` — `git clone https://github.com/httpie/cli.git
+   /tmp/httpie-demo`).
+2. `zellij delete-session httpie-demo --force` to ensure no leftover
+   serialized layout interferes.
+3. `which asciinema agg tmux ffmpeg` — all four present.
+4. Smoke test the inner/outer tmux pattern with a trivial command
+   sequence before doing the full ~4-minute take.
+5. Decide on `--dangerously-skip-permissions` for Claude. Without it,
+   the trust prompt blocks the script and you have to handle it
+   interactively — defeats the point.
 
-# Record (Ctrl-D to stop)
-asciinema rec demo.cast
+## Why not QuickTime / vhs
 
-# Render to gif (small)
-agg --speed 1.0 --font-size 14 demo.cast demo.gif
+- **QuickTime**: works, but captures the entire window including font
+  rendering, mouse cursor, focus rings — and it's not scriptable, so
+  every retake means manually nailing the timing of every keystroke.
+- **vhs (charmbracelet)**: nice for short tape-defined demos. Doesn't
+  fit here because the demo's whole point is showing *real* Claude
+  agents running in parallel, not synthesized terminal output. vhs
+  also doesn't drive a host tmux/zellij session well.
 
-# Or to mp4 via ffmpeg (gif → mp4)
-ffmpeg -i demo.gif -movflags faststart -pix_fmt yuv420p \
-  -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" demo.mp4
-```
-
-Trade-offs:
-
-- Pros: no mouse, no window borders, font-controlled, replays at exact
-  timing, can be re-rendered after the recording (font, speed, theme).
-- Cons: can't capture the Zellij sidebar transitions that live above the
-  pane content reliably — asciinema only sees what the underlying terminal
-  emulator sees, so any cursor positioning issues in your terminal show up
-  in the recording too. The QuickTime route is more faithful to "what the
-  user actually sees".
+The double-tmux + asciinema + agg approach is the only one that gets
+all three of: scriptable retakes, real Claude agents in real Zellij,
+and clean output without mouse/chrome.
 
 ## Where the artifacts live
 
-`DEMO_SCRIPT.md` at the repo root holds the narration script and pre-record
-checklist for the currently-being-recorded demo. It's kept untracked because
-it changes with every recording session — copy the previous one if you want
-a starting point.
+`DEMO_SCRIPT.md` at the repo root is the human-readable narration
+script and pre-record checklist for the currently-being-recorded
+demo. Kept untracked because it changes per take.
 
-The `demo*.mp4` and `demo*.gif` files at the repo root are **rendered
-artifacts** — they're outputs of the pipeline above. Don't commit them;
-they're large binaries and they change every recording session. The
-`.gitignore` doesn't currently exclude them by name; if you want
-belt-and-braces protection add a line like `demo*.mp4` and `demo*.gif`.
+`demo*.mp4` and `demo*.gif` at the repo root are the rendered
+artifacts. Don't commit them; they're large binaries that change
+every recording. The `.gitignore` doesn't exclude them by name
+currently — add them if you want belt-and-braces protection.

--- a/docs/RECORDING_DEMOS.md
+++ b/docs/RECORDING_DEMOS.md
@@ -1,0 +1,118 @@
+# Recording demo videos
+
+How the `demo.mp4` / `demo.gif` shipped at the repo root were produced, with the
+exact tooling and rough recipes. The script that drives the recording itself
+lives in [`DEMO_SCRIPT.md`](../DEMO_SCRIPT.md) — this doc covers the
+post-production side only.
+
+## Tools we actually used
+
+- **macOS QuickTime Player** (`⌘⇧5` → "Record Selected Portion") — primary
+  screen recording with mic audio. Produces the 1734×1080 30fps H.264 + AAC
+  `demo.mp4`. Pick the Zellij window region; uncheck "Show Floating Thumbnail";
+  set the mic input. Output lands on the desktop.
+- **`ffmpeg`** (`brew install ffmpeg`) — every cut, mute, crop, scale, and
+  encode below.
+- **`agg`** (`brew install agg`) — only used if you go down the
+  asciinema route (see "Alternate: asciinema → mp4" below).
+
+You don't need `vhs` / `terminalizer` for the current demos. The 100fps
+`demo-silent.mp4` in the tree was an asciinema export experiment from a
+different run; it isn't the source of the shipped clips.
+
+## Pipeline for the shipped clips
+
+### 1. Record
+
+QuickTime, region capture over the Zellij window. Follow the beats in
+[`DEMO_SCRIPT.md`](../DEMO_SCRIPT.md). Stop on `⌘⌃Esc`. Save as `demo-raw.mov`.
+
+### 2. Trim + mute (if needed)
+
+```bash
+# Trim to the on-script range, drop audio (for the silent variant)
+ffmpeg -ss 00:00:02 -to 00:02:18 -i demo-raw.mov \
+  -an -c:v copy demo-silent.mp4
+
+# Keep audio
+ffmpeg -ss 00:00:02 -to 00:02:18 -i demo-raw.mov \
+  -c copy demo.mp4
+```
+
+`-c copy` preserves the original codec (no re-encode). For frame-accurate
+trims drop `-c copy` and let ffmpeg re-encode.
+
+### 3. Make the GIF
+
+The shipped `demo.gif` is a 8-second 900×561 10fps clip — a short loop, not
+the whole video. Two-pass palette flow gives much smaller files than a
+naive single-pass:
+
+```bash
+# Pass 1 — extract palette from the chosen window
+ffmpeg -ss 00:00:35 -t 8 -i demo.mp4 \
+  -vf "fps=10,scale=900:-1:flags=lanczos,palettegen=stats_mode=diff" \
+  -y palette.png
+
+# Pass 2 — apply the palette
+ffmpeg -ss 00:00:35 -t 8 -i demo.mp4 -i palette.png \
+  -lavfi "fps=10,scale=900:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" \
+  -y demo.gif
+```
+
+Tune knobs:
+
+- `fps=10` — drop to 8 if file size is still too big for GitHub's ~10MB
+  inline-render cap; 15 if motion feels choppy.
+- `scale=900:-1` — match the README column. Bigger = readable text, bigger
+  file. Below 720 the terminal text gets hard to read.
+- `bayer_scale` — 5 is the dithering sweet spot for terminal output; lower
+  values produce more banding, higher values produce file-size bloat.
+
+### 4. Sanity check
+
+```bash
+ffprobe -v error -show_entries format=duration,size:stream=width,height,r_frame_rate,codec_name demo.gif
+du -h demo.mp4 demo.gif
+```
+
+GitHub inline-renders GIFs up to ~10MB; the shipped `demo.gif` lands at ~1MB.
+For longer or higher-fidelity demos prefer uploading the MP4 as a GitHub
+attachment instead — drag it into a PR or issue body and GitHub plays it
+inline.
+
+## Alternate: asciinema → mp4 (the `demo-silent.mp4` route)
+
+If you'd rather have a deterministic, scriptable terminal recording with no
+window chrome:
+
+```bash
+brew install asciinema agg
+
+# Record (Ctrl-D to stop)
+asciinema rec demo.cast
+
+# Render to gif (small)
+agg --speed 1.0 --font-size 14 demo.cast demo.gif
+
+# Or to mp4 via ffmpeg (gif → mp4)
+ffmpeg -i demo.gif -movflags faststart -pix_fmt yuv420p \
+  -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" demo.mp4
+```
+
+Trade-offs:
+
+- Pros: no mouse, no window borders, font-controlled, replays at exact
+  timing, can be re-rendered after the recording (font, speed, theme).
+- Cons: can't capture the Zellij sidebar transitions that live above the
+  pane content reliably — asciinema only sees what the underlying terminal
+  emulator sees, so any cursor positioning issues in your terminal show up
+  in the recording too. The QuickTime route is more faithful to "what the
+  user actually sees".
+
+## Where the artifacts live
+
+The `demo*.mp4` / `demo*.gif` / `DEMO_SCRIPT.md` files sit at the repo root
+and are untracked — they're build artifacts, not source. Don't commit them.
+The `.gitignore` doesn't currently exclude them by name; if you want
+belt-and-braces protection add a line like `demo*.mp4` and `demo*.gif`.

--- a/docs/RECORDING_DEMOS.md
+++ b/docs/RECORDING_DEMOS.md
@@ -2,7 +2,8 @@
 
 How the `demo.mp4` / `demo.gif` shipped at the repo root were produced, with the
 exact tooling and rough recipes. The script that drives the recording itself
-lives in [`DEMO_SCRIPT.md`](../DEMO_SCRIPT.md) — this doc covers the
+lives in a local `DEMO_SCRIPT.md` at the repo root (kept per-recording, not
+checked in) — this doc covers the
 post-production side only.
 
 ## Tools we actually used
@@ -25,7 +26,7 @@ different run; it isn't the source of the shipped clips.
 ### 1. Record
 
 QuickTime, region capture over the Zellij window. Follow the beats in
-[`DEMO_SCRIPT.md`](../DEMO_SCRIPT.md). Stop on `⌘⌃Esc`. Save as `demo-raw.mov`.
+your local `DEMO_SCRIPT.md`. Stop on `⌘⌃Esc`. Save as `demo-raw.mov`.
 
 ### 2. Trim + mute (if needed)
 
@@ -112,9 +113,10 @@ Trade-offs:
 
 ## Where the artifacts live
 
-`DEMO_SCRIPT.md` at the repo root is **source documentation** (the narration
-script and pre-record checklist) and is fine to commit when you've made
-meaningful edits.
+`DEMO_SCRIPT.md` at the repo root holds the narration script and pre-record
+checklist for the currently-being-recorded demo. It's kept untracked because
+it changes with every recording session — copy the previous one if you want
+a starting point.
 
 The `demo*.mp4` and `demo*.gif` files at the repo root are **rendered
 artifacts** — they're outputs of the pipeline above. Don't commit them;

--- a/docs/RECORDING_DEMOS.md
+++ b/docs/RECORDING_DEMOS.md
@@ -112,7 +112,12 @@ Trade-offs:
 
 ## Where the artifacts live
 
-The `demo*.mp4` / `demo*.gif` / `DEMO_SCRIPT.md` files sit at the repo root
-and are untracked — they're build artifacts, not source. Don't commit them.
-The `.gitignore` doesn't currently exclude them by name; if you want
+`DEMO_SCRIPT.md` at the repo root is **source documentation** (the narration
+script and pre-record checklist) and is fine to commit when you've made
+meaningful edits.
+
+The `demo*.mp4` and `demo*.gif` files at the repo root are **rendered
+artifacts** — they're outputs of the pipeline above. Don't commit them;
+they're large binaries and they change every recording session. The
+`.gitignore` doesn't currently exclude them by name; if you want
 belt-and-braces protection add a line like `demo*.mp4` and `demo*.gif`.


### PR DESCRIPTION
## Summary

Documents how the `demo.mp4` / `demo.gif` shipped at the repo root were produced. The main pipeline is **QuickTime screen capture → ffmpeg trim → two-pass palette GIF**, with **asciinema → agg → ffmpeg** documented as the terminal-only alternate (the 100fps `demo-silent.mp4` artifact came from this route).

Also links the new doc from the "Where to look" table in `AGENTS.md` (the `CLAUDE.md` symlink picks it up automatically).

## Test plan

- [ ] Render the doc on GitHub and confirm the codeblocks and tables display correctly
- [ ] Confirm the AGENTS.md table still renders after the new row
- [ ] Spot-check the `ffmpeg` two-pass commands by copy-pasting them and rendering a 5-second test GIF from one of the existing `demo*.mp4` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)