### PR TITLE
docs(BUILDING_WITH_AGENTS): rewrite from session-log evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ A `.claude/hooks/pre-push-block.sh` hook blocks `git push` unless prefixed with 
 |-------|-----|
 | Build, test & push instructions | [docs/BUILD.md](docs/BUILD.md) |
 | Architecture & file map | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Test layers & what each catches | [docs/TESTING.md](docs/TESTING.md) |
+| How we develop with AI agents | [docs/BUILDING_WITH_AGENTS.md](docs/BUILDING_WITH_AGENTS.md) |
 | Product & UX conventions | [docs/PRODUCT_SENSE.md](docs/PRODUCT_SENSE.md) |
 | Code conventions & Zellij gotchas | [docs/CONVENTIONS.md](docs/CONVENTIONS.md) |
 | Quality scoring | [docs/QUALITY_SCORE.md](docs/QUALITY_SCORE.md) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,8 +148,10 @@ sequenceDiagram
     Z->>P: PipeMessage broadcast to all plugins
     P->>P: filter on msg.name zelligent-status, then update AgentStatus
     P->>P: render gutter (green dot / yellow dot / green check)
-    P->>OS: osascript notification (Done, NeedsInput)
-    P->>OS: afplay Glass.aiff (NeedsInput only)
+    P->>Z: run_command osascript (Done, NeedsInput)
+    Z->>OS: spawn osascript notification process
+    P->>Z: run_command afplay Glass.aiff (NeedsInput only)
+    Z->>OS: spawn afplay process
 ```
 
 See [design-docs/agent-notifications.md](design-docs/agent-notifications.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,65 +1,214 @@
 # Architecture
 
-Zelligent has two components that work together:
+## What zelligent is, in one paragraph
 
-## CLI (`zelligent.sh`)
+Zelligent runs AI coding agents in isolated git worktrees, one per branch,
+each in its own [Zellij](https://zellij.dev) tab with a persistent left
+sidebar and a lazygit pane. It is a thin Bash CLI plus a Rust/WASM plugin
+that lives inside Zellij. The CLI handles git, layouts, and process
+lifecycle. The plugin handles the in-terminal UI — the sidebar, agent
+status, and tab navigation. Together they turn "spawn an agent on this
+branch" into a single tab in a Zellij session named after the repo.
 
-A Bash script installed as `zelligent`. Handles:
+## Why two components, not one
 
-- **Session management** — creates/attaches Zellij sessions named after the git repo (`basename` of repo root)
-- **Worktree lifecycle** — `spawn` creates git worktrees under `~/.zelligent/worktrees/<repo>/`, `remove` cleans them up
-- **Layout generation** — builds fragment-based KDL layouts for Zellij tabs (persistent sidebar + main tab body + status bar)
-- **Doctor** — `zelligent doctor` sets up Zellij config, plugin permissions, the default user layout, and the Claude Code plugin
-- **Nuke** — `zelligent nuke` force-deletes the session, its server processes, and resurrection cache
+Zellij hosts plugins inside a WASI sandbox. A plugin can render to a pane
+and call back into Zellij (open tabs, focus panes, run commands), but it
+cannot shell out arbitrarily, fork processes, or block the host. So the
+work splits naturally:
 
-The CLI resolves the main repo root even when run from a worktree (`git rev-parse --git-common-dir`).
+- **Things that need the host shell** (`git worktree add`, layout
+  generation, environment variable propagation into the agent process) live
+  in the **CLI**, which Zellij invokes via its `RunCommand` API.
+- **Things that need to live with the tab** (always-visible sidebar UI,
+  click and keyboard handling, real-time agent status from hooks) live in
+  the **WASM plugin**, which Zellij hosts inside the sidebar pane.
 
-## Zellij WASM Plugin (`plugin/`)
+This boundary is the single biggest design constraint and shows up in
+nearly every feature. Treating it as a strict separation is how the
+codebase stays small.
 
-A Rust plugin compiled to `wasm32-wasip1`. Provides the persistent sidebar UI embedded in zelligent-managed layouts. Handles:
+## The two components
 
-- **Worktree browsing** — lists worktrees, lets you switch tabs or spawn/remove worktrees
-- **Branch selection** — browse existing branches or type a new branch name
-- **Tab management** — switches to worktree tabs, closes tabs (name-based, not index-based)
-- **Agent status** — reads CLI pipe messages to show agent status (idle/working/needs-input/done) and sends OS notifications. See [design-docs/agent-notifications.md](design-docs/agent-notifications.md).
-- **Session awareness** — gets session name via `std::env::var("ZELLIJ_SESSION_NAME")` (WASI inherits host env vars)
+### CLI — `zelligent.sh` (~1300 lines of Bash)
 
-### Key file paths
+A Bash script installed as `zelligent`. Subcommands:
 
-| File | Purpose |
-|------|---------|
-| `zelligent.sh` | CLI entry point |
-| `plugin/src/lib.rs` | Plugin state machine, event handling, command dispatch |
-| `plugin/src/ui.rs` | Plugin UI rendering |
-| `plugin/tests/render_snapshots.rs` | Insta snapshot tests for UI |
-| `dev-install.sh` | Build + install CLI and WASM plugin locally |
-| `test.sh` | Full test suite runner |
-| `claude-plugin/` | Claude Code plugin (hooks for agent status notifications) |
+| Subcommand        | What it does                                                                                |
+|-------------------|---------------------------------------------------------------------------------------------|
+| `zelligent`       | Create or attach to a session named after the repo. The initial repo tab uses the sidebar layout (sidebar is a pane, not a separate tab). |
+| `spawn`           | Create a git worktree at `~/.zelligent/worktrees/<repo>/<raw-branch>`, open a new tab named after the sanitized branch. |
+| `remove`          | Delete the worktree and (when running inside Zellij) close its tab.                         |
+| `doctor`          | One-shot setup: Zellij plugin permissions, default user layout, Claude Code hook plugin.    |
+| `nuke`            | Force-kill the session, server, and resurrection cache. For "nothing else works" recovery. |
+| `list-worktrees`  | Internal — emits a TSV the plugin parses via `RunCommand`.                                  |
+| `list-branches`   | Internal — same idea, for the branch-picker UI.                                             |
+| `show-repo`       | Internal — emits repo metadata for the plugin.                                              |
 
-### How they interact
+Key invariants the CLI enforces:
 
+- **One repo = one session.** Session name = `basename(repo root)`, with
+  the repo root resolved via `git rev-parse --git-common-dir` so it works
+  identically from any worktree of the repo.
+- **One branch maps to one managed worktree path.** Tab names are
+  derived from the branch with `/` → `-` and non-`[A-Za-z0-9_-]`
+  stripped; the plugin uses the same sanitization for best-effort
+  identity. Worktrees can exist without an open tab, and user-created
+  tabs can sit alongside managed ones.
+- **Layouts are fragment-based.** The runtime layout source is
+  per-repo `.zelligent/layout.kdl` if present, else the user-level
+  `~/.zelligent/layout.kdl` (normally copied from
+  `share/default-layout.kdl` by `doctor`). The layout contains
+  placeholders `{{zelligent_sidebar}}` and `{{zelligent_children}}`,
+  plus optional `{{cwd}}` and `{{agent_cmd}}`. See
+  [references/zellij-kdl-layout.md](references/zellij-kdl-layout.md).
+
+### Plugin — `plugin/` (Rust, compiled to `wasm32-wasip1`)
+
+A Zellij plugin that renders the persistent left sidebar pane. ~3700 lines
+of Rust split across `lib.rs` (state machine, event handling) and `ui.rs`
+(ANSI rendering, viewport math).
+
+State machine modes:
+
+- `Loading` — bootstrap; waiting for first tab/worktree update
+- `BrowseWorktrees` — the default; lists worktrees, lets you switch
+  or spawn/remove
+- `SelectBranch` — pick from existing branches to make a new worktree
+- `InputBranch` — type a new branch name
+- `Confirming` — `y/n` confirmation for destructive ops
+- `NotGitRepo` — graceful fallback when sidebar loads outside a repo
+
+What the plugin does NOT do:
+
+- It does not create or remove worktrees or mutate git refs directly.
+  Worktree lifecycle (create, delete) goes through CLI
+  `spawn` / `remove`. The plugin does call host actions like
+  `dump_session_layout` and `osascript`/`afplay` for notifications.
+- It does not bundle binaries or fonts. ANSI + Unicode only; the
+  earlier powerline-glyph dependency was removed (commit `4238cff`)
+  because it complicates installs and breaks string matching in tools
+  that strip non-printable bytes.
+
+## How the components interact
+
+Spawn from inside Zellij (the simplest case; the CLI also handles
+outside-Zellij + existing-session and outside-Zellij + no-session
+modes — see `SPAWN_MODE` in `zelligent.sh`):
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as zelligent.sh
+    participant Z as Zellij
+    participant P as Sidebar plugin
+    participant A as Agent pane
+    U->>CLI: zelligent spawn feat/x claude
+    CLI->>CLI: git worktree add ~/.zelligent/worktrees/{repo}/feat/x
+    CLI->>CLI: render KDL layout into ~/.zelligent/tmp/layout-{rand}.kdl
+    CLI->>Z: zellij action new-tab --layout {file} --name feat-x
+    Z->>P: load WASM plugin into the left pane
+    Z->>A: bash -lc with ZELLIGENT_TAB_NAME=feat-x, then exec claude
+    Z-->>U: tab feat-x focused, sidebar + agent + lazygit visible
 ```
-User runs `zelligent spawn feature/foo claude`
-  -> CLI creates git worktree at ~/.zelligent/worktrees/<repo>/feature/foo
-  -> CLI renders the layout fragment into a tab layout with sidebar + tab body
-  -> CLI calls `zellij action new-tab --layout <file> --name feature-foo`
 
-User starts `zelligent` or opens a zelligent-managed tab
-  -> Zellij loads the WASM plugin as the left sidebar pane in the rendered layout
-  -> Plugin calls `zelligent list-worktrees` and `zelligent list-branches` via RunCommand
-  -> Plugin calls `zelligent spawn/remove` via RunCommand when user selects an action
+Note the path/name asymmetry: the worktree on disk uses the **raw**
+branch name (`feat/x` → `.../{repo}/feat/x`), but the Zellij tab name
+uses the sanitized form (`feat-x`).
+
+Sidebar-driven spawn (from inside the sidebar):
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant P as Sidebar plugin
+    participant Z as Zellij host
+    participant CLI as zelligent.sh
+    U->>P: press i (InputBranch), type feat/y, Enter
+    P->>P: Action Spawn(feat/y)
+    P->>Z: RunCommand — zelligent spawn feat/y claude
+    Z->>CLI: spawn (same dance as above)
+    CLI-->>Z: RunCommandResult(exit 0)
+    Z-->>P: dispatch handle_spawn_result → Action Refresh
+    P->>Z: RunCommand — zelligent list-worktrees, list-branches
+    Z-->>P: TSV results
+    P-->>U: sidebar re-renders with the new entry
+    Note over P,Z: TabUpdate arrives in parallel — a separate self-heal fires list-worktrees again if it spots an unmatched new tab
 ```
 
-### WASM plugin environment
+Agent status (hooks → plugin → notifications):
 
-See [references/zellij-plugin-api.md](references/zellij-plugin-api.md) for API details. Plugins run in a WASI sandbox but inherit the host environment (`std::env::var()` works). External operations go through Zellij's plugin API (`RunCommand`, events, pipes).
+```mermaid
+sequenceDiagram
+    participant H as Claude Code hook
+    participant Z as Zellij
+    participant P as Sidebar plugin
+    participant OS as macOS
+    H->>Z: zellij pipe --name zelligent-status --args event=Stop,tab=feat-x
+    Z->>P: PipeMessage broadcast to all plugins
+    P->>P: filter on msg.name zelligent-status, then update AgentStatus
+    P->>P: render gutter (green dot / yellow dot / green check)
+    P->>OS: osascript notification (Done, NeedsInput)
+    P->>OS: afplay Glass.aiff (NeedsInput only)
+```
 
-## Glossary
+See [design-docs/agent-notifications.md](design-docs/agent-notifications.md)
+for the full pipeline and the `ZELLIGENT_TAB_NAME` propagation trick.
 
-- **Harness tests** (`tests/harness/`): UI acceptance tests driven by a tmux session and the `test-driver` agent. Run manually, not in CI.
-- **Test harness** (general): the overall scaffolding that lets agents validate their own work — `test.sh`, CI jobs, lints, snapshot tests.
-- **Agent** (zelligent context): a Claude Code instance running in an isolated git worktree tab, not the zelligent plugin itself.
+## Key files
 
-## Claude Code Plugin (`claude-plugin/`)
+| File                                       | Purpose                                                       |
+|--------------------------------------------|---------------------------------------------------------------|
+| `zelligent.sh`                             | CLI entry point. All git and zellij-process invocations.      |
+| `plugin/src/lib.rs`                        | Plugin state machine, event handling, command dispatch.       |
+| `plugin/src/ui.rs`                         | ANSI rendering, viewport math, color/glyph constants.         |
+| `share/default-layout.kdl`                 | Shipped default sidebar layout fragment.                       |
+| `claude-plugin/plugins/zelligent/hooks/`   | Claude Code hooks that emit `zellij pipe` status events.       |
+| `claude-plugin/plugins/zelligent/skills/`  | Bundled Claude skill: `zelligent-spawn-claude`.                |
+| `.claude/skills/`                          | Project-local Claude skills: `dev-install`, `release`, `tmux`. |
+| `.claude/agents/`                          | Specialized subagents: `rust-zellij-reviewer`, `test-driver`.  |
+| `.claude/hooks/pre-push-block.sh`          | Push gate: requires `DOCS_VERIFIED=1` prefix on `git push`.    |
+| `dev-install.sh`                           | Build wasm + symlink CLI to `~/.local/bin`. Local development. |
 
-A Claude Code plugin installed by `zelligent doctor`. Provides hooks that send agent status events to the Zellij plugin via `zellij pipe`. See [design-docs/agent-notifications.md](design-docs/agent-notifications.md) for the full pipeline.
+## Cross-cutting constraints worth knowing
+
+These are the gotchas that have bitten us most often. Each has a dedicated
+design doc.
+
+- **Tab position ≠ tab index.** Zellij has an internal tab index, but
+  what `TabUpdate` exposes via `TabInfo.position` is the visual
+  position; APIs like `close_tab_with_index` expect the internal
+  index, which the plugin can't get reliably from `TabUpdate`. The
+  workaround is name-based tab operations everywhere. See
+  [design-docs/tab-management.md](design-docs/tab-management.md).
+- **Per-plugin `cwd=` is dropped on session resurrection.** Upstream
+  Zellij's KDL emitter doesn't preserve it; on rehydrate the plugin gets
+  the server's startup `cwd` instead. Worked around with a `repo_root`
+  config field that the CLI always sets. See
+  [design-docs/session-resurrection.md](design-docs/session-resurrection.md).
+- **`kill_sessions(&[&name])` kills the plugin process.** Anything after
+  that call in the same handler doesn't run.
+- **WASM plugins inherit host env.** `std::env::var("ZELLIJ_SESSION_NAME")`
+  works inside the plugin because Zellij calls `builder.inherit_env()` on
+  the WASI engine. This is how the plugin discovers its session.
+
+## Where things live in the worktree
+
+| Path                                       | What                                                        |
+|--------------------------------------------|-------------------------------------------------------------|
+| `~/.zelligent/worktrees/<repo>/<branch>`   | The actual worktree directories.                            |
+| `~/.zelligent/tmp/`                        | Temporary rendered fragment/session layout files passed to Zellij (`--new-session-with-layout` and `action new-tab --layout`). |
+| `~/.config/zellij/config.kdl`              | Plugin permissions wired up by `zelligent doctor`.          |
+| `~/.config/zellij/layouts/zelligent.kdl`   | Default user layout, also installed by `doctor`.            |
+| `~/.local/share/zelligent/zelligent-plugin.wasm` | Where the plugin wasm is installed.                    |
+| `~/Library/Caches/org.Zellij-Contributors.Zellij/...` | Upstream resurrection cache (we don't write to it). |
+
+## Related docs
+
+- [BUILD.md](BUILD.md) — build & test commands, push gate.
+- [TESTING.md](TESTING.md) — every test layer, what it catches, what it doesn't.
+- [BUILDING_WITH_AGENTS.md](BUILDING_WITH_AGENTS.md) — how Claude / Codex /
+  Gemini participate in the dev loop.
+- [PRODUCT_SENSE.md](PRODUCT_SENSE.md) — UX rules and conventions.
+- [CONVENTIONS.md](CONVENTIONS.md) — code conventions, Zellij gotchas.
+- [design-docs/index.md](design-docs/index.md) — full design-doc index.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,8 +83,10 @@ What the plugin does NOT do:
 
 - It does not create or remove worktrees or mutate git refs directly.
   Worktree lifecycle (create, delete) goes through CLI
-  `spawn` / `remove`. The plugin does call host actions like
-  `dump_session_layout` and `osascript`/`afplay` for notifications.
+  `spawn` / `remove`. The plugin can invoke host actions like
+  `dump_session_layout` and external processes (`osascript`/`afplay`
+  for notifications) — but always via Zellij's plugin API, never by
+  calling `libc` directly.
 - It does not bundle binaries or fonts. ANSI + Unicode only; the
   earlier powerline-glyph dependency was removed (commit `4238cff`)
   because it complicates installs and breaks string matching in tools

--- a/docs/BUILDING_WITH_AGENTS.md
+++ b/docs/BUILDING_WITH_AGENTS.md
@@ -35,7 +35,7 @@ training catches different things. Empirically on this repo:
 
 ```mermaid
 flowchart TD
-    A["Spawn — zelligent spawn fix/issue-N 'claude fix-the-issue'"] --> B["Claude works in the worktree<br/>can spawn sub-agents, can consult Codex"]
+    A["Spawn — zelligent spawn fix/issue-N 'claude &quot;fix the issue&quot;'"] --> B["Claude works in the worktree<br/>can spawn sub-agents, can consult Codex"]
     B --> C["Push gate — DOCS_VERIFIED=1 git push<br/>pre-push hook enforces"]
     C --> D["CI runs — test-shell + test-plugin (.github/workflows/ci.yml)"]
     D --> E["Manual Gemini review<br/>gemini -p, headless"]

--- a/docs/BUILDING_WITH_AGENTS.md
+++ b/docs/BUILDING_WITH_AGENTS.md
@@ -1,0 +1,185 @@
+# Building zelligent with agents
+
+Zelligent is itself built with AI coding agents. This doc is the meta-tour
+of how that works in practice: what role each agent plays, how the
+infrastructure makes them safe and effective, and where humans stay in
+the loop.
+
+## The cast
+
+Three agents participate in day-to-day development:
+
+| Agent       | Role                                                                                   | Surface (local tooling, not repo-defined)         |
+|-------------|----------------------------------------------------------------------------------------|---------------------------------------------------|
+| **Claude**  | Primary developer. Reads, writes, tests, ships PRs.                                    | Claude Code CLI inside a worktree pane.           |
+| **Codex**   | Second opinion. Adversarial review, rescue when Claude is stuck, sanity check on diffs.| OpenAI Codex CLI (`@openai/codex`), invoked via a personal `codex:codex-rescue` Claude Code subagent + a small companion helper script. |
+| **Gemini**  | Independent reviewer. Catches what Claude wrote and what Codex blessed.                | Google Gemini CLI (`@google/gemini-cli`), run headless via `gemini -p`. |
+
+The Codex- and Gemini-related plumbing lives in the developer's local
+`~/.claude` config and is not part of the zelligent repo itself; only
+the Claude-side bundled plugin (`claude-plugin/`) and project skills
+(`.claude/skills/`, `.claude/agents/`) ship with the repo.
+
+The pattern is "different model for each role." Self-review by the same
+model is a known weakness; an independent reviewer with different
+training catches different things. Empirically on this repo:
+
+- Gemini catches doc-and-source-of-truth mismatches and ffmpeg/CLI syntax
+  nuances. (PR #128 — DEMO_SCRIPT.md mis-classification.)
+- Codex catches reachability and "what does a clean checkout actually
+  see" bugs. (PR #128 — broken relative link to an untracked file.)
+- Both caught the same blocking issue on PR #127 (persistent-tab
+  refresh loop), independently — strong signal.
+
+## How a feature ships
+
+```mermaid
+flowchart TD
+    A["Spawn — zelligent spawn fix/issue-N 'claude fix-the-issue'"] --> B["Claude works in the worktree<br/>can spawn sub-agents, can consult Codex"]
+    B --> C["Push gate — DOCS_VERIFIED=1 git push<br/>pre-push hook enforces"]
+    C --> D["CI runs — test-shell + test-plugin (.github/workflows/ci.yml)"]
+    D --> E["Manual Gemini review<br/>gemini -p, headless"]
+    D --> F["Manual Codex review<br/>local Codex CLI"]
+    E --> G["Triage comment posted on PR<br/>blocking vs nits"]
+    F --> G
+    G -->|substantive findings| B
+    G -->|no blocking findings| H["Human merges"]
+
+    classDef agent fill:#dae8fc,stroke:#6c8ebf,color:#000
+    classDef gate fill:#fff2cc,stroke:#d6b656,color:#000
+    classDef human fill:#d5e8d4,stroke:#82b366,color:#000
+    class A,B,E,F agent
+    class C,D,G gate
+    class H human
+```
+
+## Infrastructure that makes this safe
+
+### Isolation via worktrees
+
+Every spawned agent gets its own git worktree under
+`~/.zelligent/worktrees/<repo>/<branch>` and its own Zellij tab.
+Branches don't collide on disk. Two agents working on adjacent
+features can't accidentally edit the same files in the same checkout
+because they have separate ones.
+
+### `ZELLIGENT_TAB_NAME` propagation
+
+The CLI injects `ZELLIGENT_TAB_NAME=<sanitized-branch>` into the agent
+pane's environment. Anything the agent spawns inherits it. The Claude
+Code hooks (next item) use it to identify which tab they belong to
+when they emit status events.
+
+### Agent status notifications via Claude Code hooks
+
+Installed by `zelligent doctor`. The hooks live in
+`claude-plugin/plugins/zelligent/hooks/hooks.json` and fire on three
+Claude Code events:
+
+| Hook event             | When                              | Pipe event           | Sidebar effect                |
+|------------------------|-----------------------------------|----------------------|-------------------------------|
+| `UserPromptSubmit`     | User sends a prompt to Claude     | `event=Start`        | Status → Working (green dot)  |
+| `Notification` (`permission_prompt`) | Claude asks for tool approval | `event=PermissionRequest` | Status → NeedsInput (yellow) + sound |
+| `Stop`                 | Claude finishes a turn            | `event=Stop`         | Status → Done (green check) + desktop notification |
+
+Each hook runs `zellij pipe --name zelligent-status --args
+event=<X>,tab=$ZELLIGENT_TAB_NAME`. The plugin filters incoming pipes
+on `msg.name == "zelligent-status"` and updates per-tab status. This
+is how the sidebar shows "what is every agent doing right now" at a
+glance.
+
+Full pipeline: [design-docs/agent-notifications.md](design-docs/agent-notifications.md).
+
+### Pre-push docs gate
+
+`.claude/hooks/pre-push-block.sh` is a Claude Code `PreToolUse` hook
+that blocks `Bash` commands containing `git push` unless the command
+also contains `DOCS_VERIFIED=1`. The point isn't the literal env var;
+it's the forcing function — the developer (or agent) has to stop and
+answer "are the docs current?" before push. The marker shows up in
+shell history so it's visible later. The hook is Claude-Code-specific
+and does not affect a human pushing from a normal shell.
+
+## Skills — encoding workflows the agent can execute
+
+Skills are markdown files with YAML frontmatter and a body that tells
+the agent how to execute a workflow. Claude Code discovers them by
+name/description from `.claude/skills/` (project-local) and bundled
+plugin directories like `claude-plugin/plugins/zelligent/skills/`.
+
+| Skill                       | Purpose                                                                        |
+|-----------------------------|--------------------------------------------------------------------------------|
+| `zelligent-spawn-claude`    | How an agent spawns sub-agents via `zelligent spawn`. Includes guard rails (don't delegate work whose output needs to come back to the current chat). |
+| `dev-install`               | One-command local rebuild + install of CLI and wasm. Handles the Homebrew-Rust PATH workaround. |
+| `release`                   | The release pipeline: bump VERSION, tag, push, wait for CI, update Homebrew formula, write release notes. |
+| `tmux`                      | Manual proofs and ad hoc UI interaction. Wraps a Zellij session in tmux so its output is scrapeable. |
+
+A skill is the right abstraction when a workflow is *executable but
+not autonomous* — the agent shouldn't have to re-derive the steps
+each time, but the steps need a human/agent in the loop to decide
+what to do at each branch.
+
+## Specialized subagents
+
+Subagents live in `.claude/agents/`. They are full Claude instances
+with a tighter tool list, a focused system prompt, and (sometimes) a
+specific model override.
+
+- **`test-driver`** — Drives UI test plans in tmux. Sonnet, restricted
+  to `Bash` and `Read`, with the `tmux` skill. Reads a plan markdown
+  file, runs the fixture, executes steps against a real Zellij, and
+  reports pass/fail per step. See [tests/harness/README.md](../tests/harness/README.md).
+- **`rust-zellij-reviewer`** — Reviews Rust code in the Zellij plugin
+  context. Opus, no `Bash`/`Edit`/`Write`; has read/search/web/task
+  tools. Used to validate larger plugin changes against Zellij design
+  patterns; not invoked every PR.
+
+Subagents share the workspace but get a fresh context window. They
+return a single message back. Their job is to do one thing well and
+leave; orchestration stays in the parent agent.
+
+## Memory (developer-local, not in the repo)
+
+Claude Code can maintain per-project auto-memory files outside the
+repo (typically under `~/.claude/`). It captures things that aren't in
+the code or the git history but need to survive across conversations:
+Zellij quirks the agent rediscovered, push-gate rules, build commands
+with the PATH workaround, known upstream bugs. The contents and exact
+location are part of the developer's local Claude Code setup, not
+part of zelligent itself; the same agents work without it, just with
+less context retention between sessions.
+
+## Where humans stay in the loop
+
+- Picking what to work on. (The agent doesn't decide priorities.)
+- Merging PRs. Even when CI is green and both reviewers have no
+  blocking findings.
+- Releases. The `release` skill walks the steps but waits at each
+  human decision point (release notes content, Homebrew tap PR).
+- Architecture decisions. Big design changes get a design-doc in
+  `docs/design-docs/` written by a human and reviewed by agents.
+
+## Patterns that don't work (yet)
+
+- **Self-review by the same model.** Both Claude Opus and Sonnet
+  miss things they would catch in someone else's code. The fix is
+  to route to a different model, not to ask harder.
+- **Long-running agent autonomy without checkpoints.** Empirically
+  agents drift after a few dozen turns without a human anchoring
+  step. Periodic recheck patterns (a scheduled or looped prompt that
+  re-asks "what's the current state, what's still actionable") work
+  better than open-ended autonomy.
+- **Spawning sub-agents whose output needs to come back to the
+  parent chat.** The `zelligent-spawn-claude` skill spells this out
+  explicitly: subagents in spawned worktrees can't stream feedback
+  back. For "do a thing and report to me," use the parent agent's
+  subagent tool, not `zelligent spawn`.
+
+## Related docs
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — what zelligent itself is.
+- [TESTING.md](TESTING.md) — how we verify changes.
+- `claude-plugin/plugins/zelligent/skills/zelligent-spawn-claude/SKILL.md`
+  — the bundled skill agents pick up after `zelligent doctor`.
+- [design-docs/agent-notifications.md](design-docs/agent-notifications.md)
+  — the hook + pipe pipeline.

--- a/docs/BUILDING_WITH_AGENTS.md
+++ b/docs/BUILDING_WITH_AGENTS.md
@@ -1,184 +1,207 @@
 # Building zelligent with agents
 
-Zelligent is itself built with AI coding agents. This doc is the meta-tour
-of how that works in practice: what role each agent plays, how the
-infrastructure makes them safe and effective, and where humans stay in
-the loop.
+Zelligent is itself developed with AI coding agents. This doc describes
+how that actually works, reconstructed from ~600 Claude Code session
+logs, the on-disk tooling, and the project-memory feedback files that
+capture what was learned the hard way. Not the prescriptive ideal; the
+actual practice.
 
-## The cast
+## The setup
 
-Three agents participate in day-to-day development:
+The developer runs **Claude Code** as the primary agent, with a small
+set of installed plugins doing specialized review and UI-driving work
+on the side. The plugins live in the developer's local Claude Code
+config; the in-repo `claude-plugin/` ships only the hooks (for agent
+status notifications) and the `zelligent-spawn-claude` skill.
 
-| Agent       | Role                                                                                   | Surface (local tooling, not repo-defined)         |
-|-------------|----------------------------------------------------------------------------------------|---------------------------------------------------|
-| **Claude**  | Primary developer. Reads, writes, tests, ships PRs.                                    | Claude Code CLI inside a worktree pane.           |
-| **Codex**   | Second opinion. Adversarial review, rescue when Claude is stuck, sanity check on diffs.| OpenAI Codex CLI (`@openai/codex`), invoked via a personal `codex:codex-rescue` Claude Code subagent + a small companion helper script. |
-| **Gemini**  | Independent reviewer. Catches what Claude wrote and what Codex blessed.                | Google Gemini CLI (`@google/gemini-cli`), run headless via `gemini -p`. |
+| Tool | Where it lives | What it's for |
+|------|----------------|---------------|
+| Claude Code | `claude` CLI | Primary developer. Reads, writes, tests, opens PRs. |
+| `tui-use` | `@1debit/tui-use` Claude Code plugin | PTY automation. Drives real Zellij sessions to validate UI changes. **The dominant validation tool** (≈300 invocations in the local logs vs ~13 for the tmux skill). |
+| `/code-review` | `claude-code-plugins/code-review/1.0.0` | Multi-agent PR review. Launches 5 parallel Sonnet agents, scores each finding 0–100 with a Haiku, posts only ≥80-confidence findings. |
+| `codex-companion` | `@openai/codex` + a wrapper script | Local Codex review. `node codex-companion.mjs review --background --base origin/main --scope branch` runs an independent OpenAI Codex review against the branch diff. |
+| `codex:codex-rescue` | Claude Code subagent | "I'm stuck, take over." Used to delegate when the parent agent has been spinning. Rare but load-bearing. |
+| Gemini Code Assist | GitHub App | Auto-reviews every newly opened PR within ~5 minutes. Posts as `gemini-code-assist[bot]`. Re-trigger with `/gemini review` comments on later pushes. |
+| `gemini -p` | `@google/gemini-cli` | Manual Gemini reviews for one-off correctness checks outside the PR flow. |
+| `advisor` tool | Built-in (stronger model) | Pre-substantive-work and pre-declaration sanity checks. Sees the full conversation. ~30 uses in the local logs. |
 
-The Codex- and Gemini-related plumbing lives in the developer's local
-`~/.claude` config and is not part of the zelligent repo itself; only
-the Claude-side bundled plugin (`claude-plugin/`) and project skills
-(`.claude/skills/`, `.claude/agents/`) ship with the repo.
+## What's in the repo vs in the developer's setup
 
-The pattern is "different model for each role." Self-review by the same
-model is a known weakness; an independent reviewer with different
-training catches different things. Empirically on this repo:
+**In the zelligent repo:**
 
-- Gemini catches doc-and-source-of-truth mismatches and ffmpeg/CLI syntax
-  nuances. (PR #128 — DEMO_SCRIPT.md mis-classification.)
-- Codex catches reachability and "what does a clean checkout actually
-  see" bugs. (PR #128 — broken relative link to an untracked file.)
-- Both caught the same blocking issue on PR #127 (persistent-tab
-  refresh loop), independently — strong signal.
+- `claude-plugin/plugins/zelligent/hooks/hooks.json` — Claude Code hooks
+  that fire on `UserPromptSubmit` / `Stop` / `Notification(permission_prompt)`
+  and pipe status events to the sidebar plugin via `zellij pipe`.
+- `claude-plugin/plugins/zelligent/skills/zelligent-spawn-claude/SKILL.md`
+  — bundled skill that teaches an agent how to spawn other agents via
+  `zelligent spawn`.
+- `.claude/skills/dev-install/`, `.claude/skills/release/`,
+  `.claude/skills/tmux/` — project workflows.
+- `.claude/agents/test-driver.md`, `.claude/agents/rust-zellij-reviewer.md`
+  — defined subagent personas. Rarely invoked in the actual logs;
+  validation usually happens via direct `tui-use` from the main agent.
+- `.claude/hooks/pre-push-block.sh` — `PreToolUse` hook that refuses
+  Claude Code `Bash` invocations of `git push` unless the command also
+  contains `DOCS_VERIFIED=1`. Forces docs-current acknowledgment from
+  the agent. Doesn't affect a human pushing in their own shell.
 
-## How a feature ships
+**In the developer's local Claude Code (`~/.claude/`):**
+
+- `tui-use`, `code-review`, `codex` plugins
+- The Gemini and Codex CLI binaries
+- Per-project auto-memory files in
+  `~/.claude/projects/<sanitized-path>/memory/` — feedback rules that
+  encode lessons like "always run Codex review before self-merge" and
+  "tab position ≠ tab index". These are NOT in the zelligent repo; a
+  fresh setup re-learns them.
+
+## How a feature actually ships
 
 ```mermaid
 flowchart TD
-    A["Spawn — zelligent spawn fix/issue-N 'claude &quot;fix the issue&quot;'"] --> B["Claude works in the worktree<br/>can spawn sub-agents, can consult Codex"]
-    B --> C["Push gate — DOCS_VERIFIED=1 git push<br/>pre-push hook enforces"]
-    C --> D["CI runs — test-shell + test-plugin (.github/workflows/ci.yml)"]
-    D --> E["Manual Gemini review<br/>gemini -p, headless"]
-    D --> F["Manual Codex review<br/>local Codex CLI"]
-    E --> G["Triage comment posted on PR<br/>blocking vs nits"]
-    F --> G
-    G -->|substantive findings| B
-    G -->|no blocking findings| H["Human merges"]
+    A["Directive prompt from dev<br/>e.g. 'fix the tab-close race, verify with QA'"] --> B["Claude reads, plans, edits"]
+    B --> T["tui-use validates UI<br/>(reinstall CLI + wasm first, then drive Zellij)"]
+    T --> C["bash test.sh + plugin cargo test"]
+    C --> D["DOCS_VERIFIED=1 git push<br/>(Claude Code PreToolUse hook enforces)"]
+    D --> E["Gemini Code Assist auto-reviews<br/>(GitHub App, ~5 min after open)"]
+    D --> F["Local Codex review<br/>(codex-companion review --background)"]
+    D --> G["/code-review plugin<br/>(5 parallel Sonnet agents + Haiku confidence)"]
+    E --> H["Triage: substantive vs nit<br/>diminishing-returns rule for round 3+"]
+    F --> H
+    G --> H
+    H -->|substantive findings| B
+    H -->|no blockers| I["gh pr merge --squash --delete-branch"]
 
     classDef agent fill:#dae8fc,stroke:#6c8ebf,color:#000
     classDef gate fill:#fff2cc,stroke:#d6b656,color:#000
     classDef human fill:#d5e8d4,stroke:#82b366,color:#000
-    class A,B,E,F agent
-    class C,D,G gate
-    class H human
+    class A,B,T,E,F,G,H agent
+    class C,D gate
+    class I human
 ```
 
-## Infrastructure that makes this safe
+The developer drives. Most work is one directive prompt to the main
+Claude agent, which reads the codebase, edits, dogfoods, and pushes.
+Sub-agent spawning (`zelligent spawn`) exists and works, but in
+practice the user delegates by *direction* more than by *spawning*.
+The `zelligent-spawn-claude` skill was invoked only twice across all
+zelligent sessions — it's a feature, not the day-to-day pattern.
 
-### Isolation via worktrees
+## Dogfooding is load-bearing
 
-Every spawned agent gets its own git worktree under
-`~/.zelligent/worktrees/<repo>/<branch>` and its own Zellij tab.
-Branches don't collide on disk. Two agents working on adjacent
-features can't accidentally edit the same files in the same checkout
-because they have separate ones.
+The single biggest source of friction is that **`~/.local/bin/zelligent`
+and the wasm are snapshots, not symlinks**. Editing the source doesn't
+change runtime behavior until you reinstall. The `dev-install` skill
+encapsulates the right sequence (build wasm for `wasm32-wasip1`, copy
+both artifacts in, optionally `zelligent nuke` to clear the
+resurrection cache). Every UI-validation round starts with a
+reinstall. Skip it and you're testing the previous version.
 
-### `ZELLIGENT_TAB_NAME` propagation
+## Review calibration rules that emerged from practice
 
-The CLI injects `ZELLIGENT_TAB_NAME=<sanitized-branch>` into the agent
-pane's environment. Anything the agent spawns inherits it. The Claude
-Code hooks (next item) use it to identify which tab they belong to
-when they emit status events.
+Captured in the local memory files; not in the repo. Distilled:
 
-### Agent status notifications via Claude Code hooks
+- **Run Codex review on every non-trivial PR before self-merge.** Use
+  `--base origin/main --scope branch`; the default scope is
+  working-tree and returns "no changes" post-commit. False-negative
+  trap.
+- **Don't sit idle waiting for Gemini.** Arm a `watch-pr-reviews`
+  Monitor right after pushing so the review notification lands in
+  chat.
+- **Reply to every reviewer comment** in the same round. Silent skips
+  drift over time.
+- **Calibrate accept/reject per finding.** Accept findings that hit
+  the PR's contract, a real bug, or a documented guarantee. Push back
+  on cosmetic parity or defensive detail the PR didn't promise.
+- **Diminishing-returns rule.** When round N's only finding is a
+  strictly-narrower morphological tweak to the same artifact from
+  round N-1 (same regex, same docstring, same tripwire), decline and
+  self-merge with a tracking issue. After three accept-and-iterate
+  rounds with no substantive finding, the prior shifts to bikeshedding.
+- **Codex posts at two endpoints.** The `chatgpt-codex-connector[bot]`
+  posts as a pull-request review (with inline comments), not an issue
+  comment. Check both `/pulls/<N>/reviews` and `/pulls/<N>/comments`
+  — checking only issue comments misses the review entirely.
+  Self-merging on the basis of a missed Codex review has happened.
 
-Installed by `zelligent doctor`. The hooks live in
-`claude-plugin/plugins/zelligent/hooks/hooks.json` and fire on three
-Claude Code events:
+## Agent status notifications via Claude Code hooks
 
-| Hook event             | When                              | Pipe event           | Sidebar effect                |
-|------------------------|-----------------------------------|----------------------|-------------------------------|
-| `UserPromptSubmit`     | User sends a prompt to Claude     | `event=Start`        | Status → Working (green dot)  |
-| `Notification` (`permission_prompt`) | Claude asks for tool approval | `event=PermissionRequest` | Status → NeedsInput (yellow) + sound |
-| `Stop`                 | Claude finishes a turn            | `event=Stop`         | Status → Done (green check) + desktop notification |
+When `zelligent doctor` runs, it installs the bundled Claude Code
+plugin at `claude-plugin/plugins/zelligent/`. The hooks fire on three
+Claude Code events and pipe status to the sidebar plugin:
+
+| Hook event | When | Pipe event | Sidebar effect |
+|------------|------|-----------|----------------|
+| `UserPromptSubmit` | Dev sends a prompt to Claude | `Start` | Status → Working (green dot) |
+| `Notification(permission_prompt)` | Claude asks for tool approval | `PermissionRequest` | Status → NeedsInput (yellow) + sound |
+| `Stop` | Claude finishes a turn | `Stop` | Status → Done (green check) + desktop notification |
 
 Each hook runs `zellij pipe --name zelligent-status --args
-event=<X>,tab=$ZELLIGENT_TAB_NAME`. The plugin filters incoming pipes
-on `msg.name == "zelligent-status"` and updates per-tab status. This
-is how the sidebar shows "what is every agent doing right now" at a
-glance.
+event=<X>,tab=$ZELLIGENT_TAB_NAME`. The plugin filters on
+`msg.name == "zelligent-status"` and updates per-tab status. The
+`ZELLIGENT_TAB_NAME` env var is injected by `zelligent spawn` into
+the agent pane and propagates to every child process.
 
 Full pipeline: [design-docs/agent-notifications.md](design-docs/agent-notifications.md).
 
-### Pre-push docs gate
+## Project memory
 
-`.claude/hooks/pre-push-block.sh` is a Claude Code `PreToolUse` hook
-that blocks `Bash` commands containing `git push` unless the command
-also contains `DOCS_VERIFIED=1`. The point isn't the literal env var;
-it's the forcing function — the developer (or agent) has to stop and
-answer "are the docs current?" before push. The marker shows up in
-shell history so it's visible later. The hook is Claude-Code-specific
-and does not affect a human pushing from a normal shell.
+`~/.claude/projects/<sanitized-path>/memory/MEMORY.md` (and the
+related `feedback_*.md` files) accumulate the "this surprised me
+once, let's not be surprised twice" facts. Examples from the
+zelligent project memory:
 
-## Skills — encoding workflows the agent can execute
+- WASM plugins inherit host env vars (`std::env::var` works).
+- `split_direction="Vertical"` is the left/right split, not
+  top/bottom — counterintuitive, breaks the sidebar layout if you
+  get it wrong.
+- `dump-layout` normalizes split direction to lowercase.
+- `TabInfo.position` ≠ tab index; use name-based ops.
+- `kill_sessions(&[&name])` terminates the plugin's own process —
+  nothing after that call runs.
+- `~/.local/bin/zelligent` and `.wasm` are snapshots, not links.
 
-Skills are markdown files with YAML frontmatter and a body that tells
-the agent how to execute a workflow. Claude Code discovers them by
-name/description from `.claude/skills/` (project-local) and bundled
-plugin directories like `claude-plugin/plugins/zelligent/skills/`.
+These survive across conversations and seed each new agent session.
+The memory is not part of the repo — a fresh setup re-learns them.
+The sibling `hapi` project has a much larger memory bank with formal
+review rules (`feedback_codex_review_every_pr.md`,
+`feedback_pr_reviewers.md`, `feedback_review_round_diminishing_returns.md`,
+etc.); the zelligent workflow inherits the principles informally.
 
-| Skill                       | Purpose                                                                        |
-|-----------------------------|--------------------------------------------------------------------------------|
-| `zelligent-spawn-claude`    | How an agent spawns sub-agents via `zelligent spawn`. Includes guard rails (don't delegate work whose output needs to come back to the current chat). |
-| `dev-install`               | One-command local rebuild + install of CLI and wasm. Handles the Homebrew-Rust PATH workaround. |
-| `release`                   | The release pipeline: bump VERSION, tag, push, wait for CI, update Homebrew formula, write release notes. |
-| `tmux`                      | Manual proofs and ad hoc UI interaction. Wraps a Zellij session in tmux so its output is scrapeable. |
+## What humans still own
 
-A skill is the right abstraction when a workflow is *executable but
-not autonomous* — the agent shouldn't have to re-derive the steps
-each time, but the steps need a human/agent in the loop to decide
-what to do at each branch.
-
-## Specialized subagents
-
-Subagents live in `.claude/agents/`. They are full Claude instances
-with a tighter tool list, a focused system prompt, and (sometimes) a
-specific model override.
-
-- **`test-driver`** — Drives UI test plans in tmux. Sonnet, restricted
-  to `Bash` and `Read`, with the `tmux` skill. Reads a plan markdown
-  file, runs the fixture, executes steps against a real Zellij, and
-  reports pass/fail per step. See [tests/harness/README.md](../tests/harness/README.md).
-- **`rust-zellij-reviewer`** — Reviews Rust code in the Zellij plugin
-  context. Opus, no `Bash`/`Edit`/`Write`; has read/search/web/task
-  tools. Used to validate larger plugin changes against Zellij design
-  patterns; not invoked every PR.
-
-Subagents share the workspace but get a fresh context window. They
-return a single message back. Their job is to do one thing well and
-leave; orchestration stays in the parent agent.
-
-## Memory (developer-local, not in the repo)
-
-Claude Code can maintain per-project auto-memory files outside the
-repo (typically under `~/.claude/`). It captures things that aren't in
-the code or the git history but need to survive across conversations:
-Zellij quirks the agent rediscovered, push-gate rules, build commands
-with the PATH workaround, known upstream bugs. The contents and exact
-location are part of the developer's local Claude Code setup, not
-part of zelligent itself; the same agents work without it, just with
-less context retention between sessions.
-
-## Where humans stay in the loop
-
-- Picking what to work on. (The agent doesn't decide priorities.)
-- Merging PRs. Even when CI is green and both reviewers have no
-  blocking findings.
-- Releases. The `release` skill walks the steps but waits at each
-  human decision point (release notes content, Homebrew tap PR).
-- Architecture decisions. Big design changes get a design-doc in
-  `docs/design-docs/` written by a human and reviewed by agents.
+- Picking what to work on. The directive prompt sets the scope.
+- Calling merge. Even when CI is green and reviewers have no blockers,
+  the human runs `gh pr merge`.
+- Cutting releases. The `release` skill walks the steps but the human
+  approves the release notes and the Homebrew tap PR.
+- The big design moves. New architecture goes in `docs/design-docs/`
+  written by a human and reviewed by agents.
 
 ## Patterns that don't work (yet)
 
-- **Self-review by the same model.** Both Claude Opus and Sonnet
-  miss things they would catch in someone else's code. The fix is
-  to route to a different model, not to ask harder.
-- **Long-running agent autonomy without checkpoints.** Empirically
-  agents drift after a few dozen turns without a human anchoring
-  step. Periodic recheck patterns (a scheduled or looped prompt that
-  re-asks "what's the current state, what's still actionable") work
-  better than open-ended autonomy.
+- **Self-review by the same model.** Claude Opus and Sonnet
+  systematically miss things they would catch in someone else's code.
+  Route to a different model (Codex GPT-5 family, Gemini), not "ask
+  harder."
+- **Long-running agent autonomy without checkpoints.** Agents drift
+  after a few dozen turns without a re-anchoring step. The `/loop`
+  slash command paired with `ScheduleWakeup` works because every fire
+  re-asks "what's the current state, what's actionable now" —
+  converts open-ended autonomy into a checkpointed series of short
+  turns. This very session used that pattern to ship multiple PRs.
 - **Spawning sub-agents whose output needs to come back to the
-  parent chat.** The `zelligent-spawn-claude` skill spells this out
-  explicitly: subagents in spawned worktrees can't stream feedback
-  back. For "do a thing and report to me," use the parent agent's
-  subagent tool, not `zelligent spawn`.
+  parent.** The `zelligent-spawn-claude` skill explicitly warns
+  against this — subagents in spawned worktrees can't stream
+  feedback back to the parent's chat. For "do a thing and report to
+  me," use the parent's `Agent` tool, not `zelligent spawn`.
+- **Sitting idle waiting for an external review.** Arm a watcher and
+  keep working.
 
 ## Related docs
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — what zelligent itself is.
-- [TESTING.md](TESTING.md) — how we verify changes.
+- [TESTING.md](TESTING.md) — the test layers.
 - `claude-plugin/plugins/zelligent/skills/zelligent-spawn-claude/SKILL.md`
   — the bundled skill agents pick up after `zelligent doctor`.
 - [design-docs/agent-notifications.md](design-docs/agent-notifications.md)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -111,7 +111,7 @@ What it covers (one section per topic):
 
 | Section                       | What it checks                                                                  |
 |-------------------------------|---------------------------------------------------------------------------------|
-| Session name generation       | Branch → tab name sanitization (`/` → `-`, strip non-alnum).                    |
+| Session name generation       | Branch → sanitized name (`/` → `-`, strip non-alnum). The label is historical: the sanitized output is what becomes the *tab* name; session names are the repo's basename. |
 | Layout file generation        | Spawned-tab layout has sidebar, lazygit, status-bar, the right `cwd`, setup.sh. |
 | Layout source resolution      | `.zelligent/layout.kdl` precedence over user layout, validation of placeholders.|
 | Quoted agent command          | Single-quotes in agent args escape through the perl renderer and KDL emitter.   |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,281 @@
+# Testing
+
+Zelligent has six test layers, from fast and exhaustive at the bottom
+to slow and partial at the top. Each layer catches different bugs; none
+of them alone is enough.
+
+```mermaid
+flowchart TB
+    L6["Layer 6 — Manual / production"]:::slow
+    L5["Layer 5 — UI harness (tmux)"]:::ui
+    L4["Layer 4 — Integration (real Zellij in CI)"]:::integ
+    L3["Layer 3 — Shell tests (test.sh)"]:::shell
+    L2["Layer 2 — Plugin snapshot tests"]:::snap
+    L1["Layer 1 — Plugin unit tests"]:::fast
+
+    L6 --> L5 --> L4 --> L3 --> L2 --> L1
+
+    classDef slow fill:#fff2cc,stroke:#d6b656,color:#000
+    classDef ui fill:#ffe6cc,stroke:#d79b00,color:#000
+    classDef integ fill:#dae8fc,stroke:#6c8ebf,color:#000
+    classDef shell fill:#d5e8d4,stroke:#82b366,color:#000
+    classDef snap fill:#e1d5e7,stroke:#9673a6,color:#000
+    classDef fast fill:#f8cecc,stroke:#b85450,color:#000
+```
+
+The local shell gate is `bash test.sh` — it covers Layer 3 plus the
+Layer 4 integration smoke when Zellij is available. Plugin unit and
+snapshot tests (Layers 1 and 2) are separate `cargo test` runs. CI
+runs both gates as `test-shell` and `test-plugin` jobs in
+`.github/workflows/ci.yml`; both must pass before merge. The push gate
+(`.claude/hooks/pre-push-block.sh`) requires `DOCS_VERIFIED=1 git push`
+on top of that.
+
+---
+
+## Layer 1 — Plugin unit tests (~124 tests)
+
+Where: `plugin/src/lib.rs`, inside `#[cfg(test)] mod tests`. Pure Rust,
+no I/O. They test the state machine: given an `Event`, what `Action`
+does the handler return, and what does the new state look like.
+
+What they catch:
+
+- State transitions (focus changes, mode switches, confirmation flows).
+- Edge cases in parsers (`parse_branches`, `parse_worktrees`).
+- The match-by-name vs match-by-position trap (tab management).
+- Race-condition guards (the "user tab" mislabel that PR #127 fixed
+  has a specific test pinning the pre/post-snapshot diff behavior).
+
+What they miss:
+
+- Anything that requires the Zellij host shim (FFI into
+  `_host_run_plugin_command`). The plugin's `fire_*` helpers and the
+  `execute()` Action dispatcher call into it; tests cannot link these
+  in. We side-step this by extracting predicates into pure helpers and
+  testing those, then trusting the thin dispatcher.
+- Rendering. That's the next layer.
+
+Run:
+
+```bash
+cd plugin && cargo test --target "$(rustc -vV | awk '/^host:/ {print $2}')"
+```
+
+The `--target` override is required because `plugin/.cargo/config.toml`
+defaults to `wasm32-wasip1` and you can't run wasm test binaries on a
+host runner.
+
+---
+
+## Layer 2 — Plugin render snapshot tests (~32 snapshots, ~27 tests)
+
+Where: `plugin/tests/render_snapshots.rs` plus `plugin/tests/snapshots/*.snap`.
+Uses [insta](https://insta.rs).
+
+Each test constructs a `State`, calls `render_to_string(&state, rows,
+cols)` — most use 20×80, with a few explicit short/narrow cases
+(10×80, 5×80, 20×44) — and compares the normalized ANSI string against
+a checked-in `.snap` file. (The version string in the footer is
+normalized so snapshots survive version bumps.) Snapshots cover the
+main modes and flows: empty, browsing, branch-picker, input,
+confirmation, dim/highlight treatments.
+
+What they catch:
+
+- Visual regressions — gutter glyphs, color codes, dimming, viewport
+  scrolling, truncation, sidebar item ordering.
+- Off-by-ones in the cursor / viewport math when `selected_index`
+  approaches the top or bottom of the visible window.
+- Accidental introduction of non-printable bytes (the powerline glyph
+  episode — see `4238cff` — silently broke Edit-tool string matching
+  because the byte sequence was being dropped by some readers).
+
+Updating: when an intentional UI change lands, regenerate with
+
+```bash
+cd plugin && INSTA_UPDATE=always cargo test \
+  --target "$(rustc -vV | awk '/^host:/ {print $2}')"
+```
+
+Review each `.snap` diff before committing.
+
+---
+
+## Layer 3 — Shell tests (`test.sh`, ~200+ checks)
+
+Where: `test.sh`. A single Bash file that runs in ~30 seconds. Sectioned
+by `echo "<section>:"` lines that group related assertions.
+
+What it covers (one section per topic):
+
+| Section                       | What it checks                                                                  |
+|-------------------------------|---------------------------------------------------------------------------------|
+| Session name generation       | Branch → tab name sanitization (`/` → `-`, strip non-alnum).                    |
+| Layout file generation        | Spawned-tab layout has sidebar, lazygit, status-bar, the right `cwd`, setup.sh. |
+| Layout source resolution      | `.zelligent/layout.kdl` precedence over user layout, validation of placeholders.|
+| Quoted agent command          | Single-quotes in agent args escape through the perl renderer and KDL emitter.   |
+| Prompt delivery harness       | Positional prompts, `-p` prompts, model flags, and bare `claude` survive the emitted KDL → bash path. |
+| Version and help              | `--version`, `--help`.                                                          |
+| No-args behavior              | `zelligent` with no args either attaches or creates with the right layout.      |
+| Stale socket timeout          | Hanging `zellij list-sessions` falls back to "create new session" after 3s.     |
+| Argument validation           | `spawn` / `remove` reject empty or invalid input.                               |
+| Environment checks            | Required env (`HOME`, `git`) is sanity-checked.                                 |
+| Nuke subcommand               | Kills the session, then the cache, in the right order.                          |
+| Doctor subcommand             | Installs the layout, plugin perms, and Claude skill idempotently.               |
+| Install script contract       | `dev-install.sh` and Homebrew formula behavior stay in sync.                    |
+| Query subcommands             | `list-worktrees`, `list-branches`, `show-repo` produce the TSV the plugin parses.|
+| Launch mode                   | Inside-Zellij vs attach-to-existing vs new-session branch selection.            |
+| Integration (requires Zellij) | (See Layer 4.)                                                                  |
+| Doc index completeness        | Every `docs/design-docs/*.md` is linked from `docs/design-docs/index.md`.       |
+
+How it works: most tests build a temp dir, stub `zellij` and `lazygit`
+with shell scripts that echo their args, then run `zelligent` with
+`PATH` pointing at the stubs. The Prompt delivery harness goes
+further — it stubs `claude` and *executes* the emitted KDL `args` line
+through `bash -lc` so the test sees what the agent would actually see.
+
+What it catches:
+
+- All the CLI's user-visible contracts (the `Usage:` lines, the
+  error messages, the exit codes).
+- Layout-format regressions — the most fragile surface in the codebase
+  because Zellij is strict and silent about KDL parse errors.
+- The two recent close-the-tab fixes (PRs #119, #127) are pinned by
+  shell-test assertions that watch a mock zellij's argv log.
+
+What it misses:
+
+- Whether Zellij actually interprets the emitted layout correctly
+  beyond the assertions we wrote. That's Layer 4.
+- Anything visual.
+
+---
+
+## Layer 4 — Integration (live Zellij when available)
+
+Where: the `Integration (requires Zellij):` section of `test.sh` (last
+~30 lines).
+
+How it works: spins up a real Zellij session via
+`zellij attach --create-background`, spawns a worktree into it, and
+asserts on `zellij action dump-layout` output. `test.sh` skips this
+section when `zellij` isn't on `PATH` — so it runs locally (when
+Zellij is installed) and on CI runners that already have Zellij.
+Note: the current `ci.yml` does not install Zellij before `test-shell`,
+so this layer's coverage on CI depends on the runner image.
+
+What it catches:
+
+- KDL that parses in our perl renderer but fails at Zellij's KDL parser.
+- Split-direction semantics (`split_direction="Vertical"` is the
+  left/right split, not what the word says — `dump-layout` is the
+  authoritative check).
+
+Known flake: `script exits 0 (integration)` occasionally returns
+exit 2 instead of 0. Tracked but un-fixed because it shows up only on
+loaded CI runners and not locally; one-off pre-existing noise.
+
+CI definition is in `.github/workflows/ci.yml`: two macOS jobs,
+`test-shell` and `test-plugin`, both required to pass before merge.
+
+---
+
+## Layer 5 — UI harness (`tests/harness/`, tmux-driven)
+
+Where: `tests/harness/plans/*.md`, run by the
+`test-driver` subagent (`.claude/agents/test-driver.md`). Not in CI.
+
+How it works:
+
+- Each **plan** is a markdown file with YAML frontmatter specifying a
+  setup `fixture` and a `launch` command, then a numbered list of test
+  steps with expectations.
+- The `test-driver` subagent reads the plan, runs the fixture, opens a
+  dedicated tmux session on an isolated socket (`zt-driver-test`),
+  launches Zellij in window 0, and drives input from window 1.
+- After each step, it captures `tmux capture-pane` output and verifies
+  visible expectations — sidebar contents, focused tab, prompts,
+  notifications.
+
+Active plans live in `tests/harness/plans/`:
+
+- `empty-repo.md` — first-run behavior with no worktrees.
+- `with-worktrees.md` — sidebar populated, switching tabs.
+- `sidebar-layout-smoke.md` — split direction, widths, sidebar visible.
+- `sidebar-mouse-interaction.md` — click-to-focus.
+
+What this layer catches that shell tests can't:
+
+- Cursor placement, color rendering inside a real terminal, redraw
+  behavior on resize.
+- Modal flows that span multiple events (open input, type, confirm).
+- Tab focus surviving a worktree spawn from inside the sidebar.
+
+Cost: each plan takes 30–90 seconds and requires a Claude session to
+drive. We run these on demand — when something visible has changed —
+not on every commit. For ad hoc inspection, the
+[tmux skill](../.claude/skills/tmux/SKILL.md) gives you the same
+primitives without the plan harness.
+
+---
+
+## Layer 6 — Manual / production
+
+What's left uncovered by 1–5:
+
+- The actual feel of spawning and removing worktrees in real Zellij,
+  with a real agent (Claude or Codex) running in the panes. Layer 5
+  uses a stub launcher and doesn't watch a live agent.
+- Resurrection — re-attaching to a session whose layout was persisted
+  to Zellij's cache. The cwd bug (PR #105) was hit in production
+  before we knew to look for it.
+- Notifications — `osascript` and `afplay` only work on macOS with a
+  desktop session; nothing in CI checks them.
+- Homebrew installs — the formula contract is shell-tested but the
+  actual brew install / upgrade path is exercised by hand.
+
+For these we rely on:
+
+- **Dogfooding.** The repo's `.claude/skills/dev-install/SKILL.md` and
+  `.claude/skills/release/skill.md` are the canonical install paths
+  for working on zelligent inside zelligent. The contributor is also
+  the first user of every change.
+- **Release checklists.** The `release` skill walks through
+  bump → tag → CI → release notes → Homebrew formula.
+- **Demo recording.** The README demo is regenerated when behavior
+  changes; the act of recording it surfaces UI rough edges
+  ([RECORDING_DEMOS.md](RECORDING_DEMOS.md)).
+
+---
+
+## What each layer is good for, in one sentence
+
+| Layer                | One-sentence summary                                                              |
+|----------------------|-----------------------------------------------------------------------------------|
+| 1. Plugin unit       | "Given an event, does the state machine do the right thing?" Fast and exhaustive. |
+| 2. Plugin snapshot   | "Does the sidebar still render byte-for-byte the way it did before?" Catches visual regressions. |
+| 3. Shell `test.sh`   | "Does the CLI's user-visible behavior still hold?" The big one — runs in ~30s.    |
+| 4. Integration       | "Does Zellij actually accept the layout we emit?" Runs locally and on CI runners that have Zellij. |
+| 5. UI harness (tmux) | "Does the live, redrawn UI behave correctly under input?" On-demand, agent-driven.|
+| 6. Manual            | "Does the thing actually feel right when a real human runs it?" Dogfooding.       |
+
+---
+
+## Push gate
+
+Not strictly a test layer, but worth knowing: `.claude/hooks/pre-push-block.sh`
+blocks `git push` unless the command is prefixed with `DOCS_VERIFIED=1`.
+It exists so the human pushing is forced to acknowledge that
+`docs/` and `AGENTS.md` are up to date — *or* explicitly state they
+don't need updates. CI is the contract; this hook is the cultural
+contract.
+
+## Related docs
+
+- [BUILD.md](BUILD.md) — exact commands and paths.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — what the system is, why it splits the way it does.
+- [BUILDING_WITH_AGENTS.md](BUILDING_WITH_AGENTS.md) — how the tests
+  feed back into the agent-driven dev loop.
+- `tests/harness/README.md` — UI harness specifics and the
+  `test-driver` subagent.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -244,8 +244,9 @@ For these we rely on:
 - **Release checklists.** The `release` skill walks through
   bump → tag → CI → release notes → Homebrew formula.
 - **Demo recording.** The README demo is regenerated when behavior
-  changes; the act of recording it surfaces UI rough edges
-  ([RECORDING_DEMOS.md](RECORDING_DEMOS.md)).
+  changes; the act of recording it surfaces UI rough edges (the
+  pipeline for that lives in `docs/RECORDING_DEMOS.md` on the
+  recording-demos branch).
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -266,11 +266,13 @@ For these we rely on:
 ## Push gate
 
 Not strictly a test layer, but worth knowing: `.claude/hooks/pre-push-block.sh`
-blocks `git push` unless the command is prefixed with `DOCS_VERIFIED=1`.
-It exists so the human pushing is forced to acknowledge that
-`docs/` and `AGENTS.md` are up to date — *or* explicitly state they
-don't need updates. CI is the contract; this hook is the cultural
-contract.
+is a Claude Code `PreToolUse` hook that blocks `Bash` invocations of
+`git push` unless the command also contains `DOCS_VERIFIED=1`. It
+forces the agent (or developer working inside Claude Code) to
+acknowledge that `docs/` and `AGENTS.md` are up to date — *or*
+explicitly state they don't need updates. Pushing from a normal
+shell isn't blocked; CI is the contract, this hook is the cultural
+contract for agent-driven pushes.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

The version of \`docs/BUILDING_WITH_AGENTS.md\` that landed in #129 was extrapolated from one session's surface patterns. After digging through ~600 Claude Code session logs + the on-disk plugins and project memory, several claims turned out to be wrong or missing.

This PR replaces the file with one written from actual evidence.

## Corrections

| Old claim | What the logs/disk show |
|---|---|
| Three symmetric agents (Claude, Codex, Gemini) | Claude does the work; **tui-use** plugin is the dominant validation tool (~300 invocations vs ~13 for the tmux skill); Gemini is a GitHub App auto-reviewing on PR open, not just headless \`gemini -p\`. |
| No mention of \`/code-review\` plugin | It's the in-Claude-Code multi-agent review: 5 parallel Sonnet agents + Haiku confidence scoring, posts only ≥80-confidence findings. |
| zelligent-spawn-claude is "how Claude spawns sub-agents" | Skill exists but used **only twice** in all sessions. Day-to-day pattern is direct-prompting the main agent. |
| Dogfooding handwaved | Load-bearing: \`~/.local/bin/zelligent\` and the wasm are **snapshots, not symlinks**. Captured in \`feedback_dogfood_install_discipline.md\`. |
| \`/loop\` + \`ScheduleWakeup\` were "developer-local, not in repo" | They're real Claude Code runtime features actively used; this very session shipped multiple PRs via the loop. |

Also captured the review-calibration rules from the project-memory feedback files: diminishing-returns rule, "Codex posts at two GitHub endpoints" trap, "arm a watcher, don't sit idle," etc.

Verified the mermaid \`How a feature ships\` diagram still renders via headless Chrome.

## Test plan

- [ ] Open the file on GitHub, confirm the mermaid chart renders
- [ ] Skim for any remaining over-claims